### PR TITLE
Fix issue with ES6 imports when installing via npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ogl",
     "version": "0.0.5",
     "description": "WebGL Framework",
-    "main": "src/OGL.js",
+    "main": "src",
     "directories": {
         "example": "examples"
     },

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export * from './Core.js';
+export * from './Extras.js';


### PR DESCRIPTION
Hi Nathan,
I noticed a recent version caused imports to break when using ogl via npm. This update changes the main entry point in package.json to use `src/index.js` but leaves Core.js and Extras.js (an all examples) working as-is. Thanks for all your work on this - really excited to see it come to life!