### PR TITLE
Fix bottom parameter of orthographic camera

### DIFF
--- a/src/core/Camera.js
+++ b/src/core/Camera.js
@@ -50,7 +50,7 @@ export class Camera extends Transform {
         far = this.far,
         left = -1,
         right = 1,
-        bottom = 1,
+        bottom = -1,
         top = 1,
     } = {}) {
         this.projectionMatrix.fromOrthogonal({left, right, bottom, top, near, far});


### PR DESCRIPTION
Bottom should be `-1`, not `1` and will currently result in `-Infinity` and `Infinity` being set in the matrix. See https://github.com/mrdoob/three.js/blob/master/src/cameras/OrthographicCamera.js.

Kind regards,

Tim