### PR TITLE
Add simple build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+node_modules
+dist/

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
     "name": "ogl",
     "version": "0.0.21",
     "description": "WebGL Framework",
-    "main": "src",
+    "module": "dist/ogl.mjs",
+    "main": "dist/ogl.js",
     "directories": {
         "example": "examples"
     },
     "scripts": {
+        "build": "rollup -c",
+        "prebulish": "npm run build",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {
@@ -25,7 +28,8 @@
     "bugs": {
         "url": "https://github.com/oframe/ogl/issues"
     },
-    "dependencies": {
+    "devDependencies": {
+        "rollup": "^1.20.3"
     },
     "homepage": "https://github.com/oframe/ogl#readme"
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "WebGL Framework",
     "module": "dist/ogl.mjs",
     "main": "dist/ogl.js",
+    "unpkg": "dist/ogl.umd.js",
     "directories": {
         "example": "examples"
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,11 @@
+import pkg from './package.json';
+
+export default [
+	{
+		input: 'src/index.js',
+		output: [
+			{ file: pkg.main, format: 'cjs' },
+			{ file: pkg.module, format: 'es' }
+		]
+	}
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,10 @@
 import pkg from './package.json';
 
-export default [
-	{
-		input: 'src/index.js',
-		output: [
-			{ file: pkg.main, format: 'cjs' },
-      { file: pkg.module, format: 'es' },
-      { file: pkg.browser, format: 'umd', name: 'ogl' }
-		]
-	}
-];
+export default [{
+  input: 'src/index.js',
+  output: [
+    { file: pkg.main, format: 'cjs' },
+    { file: pkg.module, format: 'es' },
+    { file: pkg.browser, format: 'umd', name: 'ogl' }
+  ]
+}];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,8 @@ export default [
 		input: 'src/index.js',
 		output: [
 			{ file: pkg.main, format: 'cjs' },
-			{ file: pkg.module, format: 'es' }
+      { file: pkg.module, format: 'es' },
+      { file: pkg.browser, format: 'umd', name: 'ogl' }
 		]
 	}
 ];


### PR DESCRIPTION
I experimented with added rollup to add support for commonjs and es modules. The build is automatically done when the package is published. This is a potential fix for #18. Everything should still be tree-shakable when used as ES module.

This also enables production builds for people that just want to use OGL with [unpkg](https://unpkg.com/) - good for quick prototyping in projects without build steps, like codepen etc.

```html
<script src="https://unpkg.com/ogl"></script>
```

This introduces do introduce a single development dependency though – I've put it up here for discussion.