### PR TITLE
Fix: set mesh visiblity will be override by shadow rendering.

### DIFF
--- a/src/extras/Shadow.js
+++ b/src/extras/Shadow.js
@@ -73,7 +73,7 @@ export class Shadow {
             if (!!~this.castMeshes.indexOf(node)) {
                 node.program = node.depthProgram;
             } else {
-                if (node.visible) node.isForceVisibility = true;
+                node.isForceVisibility = node.visible;
                 node.visible = false;
             }
         });
@@ -91,7 +91,7 @@ export class Shadow {
             if (!!~this.castMeshes.indexOf(node)) {
                 node.program = node.colorProgram;
             } else {
-                if (node.isForceVisibility) node.visible = true;
+                node.visible = node.isForceVisibility;
             }
         });
     }


### PR DESCRIPTION
Shadow rendering will leave a `isForceVisibility: true` prop in mesh object. When we reset the mesh.visible to false, it will be override to true when shadow rendered.