### PR TITLE
Fix missing `this` in Shadow.js

### DIFF
--- a/src/extras/Shadow.js
+++ b/src/extras/Shadow.js
@@ -52,7 +52,7 @@ export class Shadow {
         }
 
         // Create custom override program
-        mesh.depthProgram = new Program(gl, {
+        mesh.depthProgram = new Program(this.gl, {
             vertex,
             fragment,
             cullFace: null,


### PR DESCRIPTION
Shadow used a global `gl` variable. I suspect this worked in the examples because a `gl` constant already was defined at the top level.