### PR TITLE
Use async fetch for createImageBitmap

### DIFF
--- a/src/extras/TextureLoader.js
+++ b/src/extras/TextureLoader.js
@@ -192,22 +192,19 @@ function powerOfTwo(value) {
 
 function decodeImage(src) {
     return new Promise((resolve) => {
-        const img = new Image();
-        img.crossOrigin = '';
-        img.src = src;
-
         // Only chrome's implementation of createImageBitmap is fully supported
         const isChrome = navigator.userAgent.toLowerCase().includes('chrome');
         if (!!window.createImageBitmap && isChrome) {
-            img.onload = () => {
-                createImageBitmap(img, {
-                    imageOrientation: 'flipY',
-                    premultiplyAlpha: 'none',
-                }).then((imgBmp) => {
-                    resolve(imgBmp);
-                });
+            fetch(src)
+                .then(r => r.blob())
+                .then(b => createImageBitmap(img, { imageOrientation: 'flipY', premultiplyAlpha: 'none' }))
+                .then(resolve);
             };
         } else {
+            const img = new Image();
+
+            img.crossOrigin = '';
+            img.src = src;
             img.onload = () => resolve(img);
         }
     });

--- a/src/extras/TextureLoader.js
+++ b/src/extras/TextureLoader.js
@@ -195,9 +195,9 @@ function decodeImage(src) {
         // Only chrome's implementation of createImageBitmap is fully supported
         const isChrome = navigator.userAgent.toLowerCase().includes('chrome');
         if (!!window.createImageBitmap && isChrome) {
-            fetch(src)
+            fetch(src, { mode: 'cors' })
                 .then(r => r.blob())
-                .then(b => createImageBitmap(img, { imageOrientation: 'flipY', premultiplyAlpha: 'none' }))
+                .then(b => createImageBitmap(b, { imageOrientation: 'flipY', premultiplyAlpha: 'none' }))
                 .then(resolve);
         } else {
             const img = new Image();

--- a/src/extras/TextureLoader.js
+++ b/src/extras/TextureLoader.js
@@ -199,7 +199,6 @@ function decodeImage(src) {
                 .then(r => r.blob())
                 .then(b => createImageBitmap(img, { imageOrientation: 'flipY', premultiplyAlpha: 'none' }))
                 .then(resolve);
-            };
         } else {
             const img = new Image();
 


### PR DESCRIPTION
There are difference between `createImageBitmap` from Image and from raw binary data.

When you pass `Image` to `createImageBItmap`  then image will be decode in Main thread because Image instance can't be used in Worker Pool. 
There are not difference between Image and ImageBitmap for this case when it used as texture.

For async (non blocking decoding) we MUST use a fetch API (or XHR) and pass Blob as image source to `createImageBitmap`. 

Proof:

https://jsfiddle.net/r2bjg1L4/3/

Looking to profiler tab. You can see that Image Decoding runs in main thread and for 4k image took about 50 ms per image, but fetch is ok and main thread is not frozen.

![Screenshot_1](https://user-images.githubusercontent.com/12572222/120293257-bd015f00-c2cd-11eb-9e59-752d12d0a45f.png)

