### PR TITLE
Introduce FOV Zooming option to Orbit Controls

### DIFF
--- a/examples/assets/main.css
+++ b/examples/assets/main.css
@@ -174,3 +174,7 @@ canvas {
     top: 0;
     left: 0;
 }
+
+#dropdown {
+    margin: 1em 0em;
+}

--- a/examples/cube-map.html
+++ b/examples/cube-map.html
@@ -13,7 +13,16 @@
         <link href="assets/main.css" rel="stylesheet" />
     </head>
     <body>
-        <div class="Info">Cube Map. Texture by <a href="http://www.humus.name" target="_blank">Humus</a></div>
+        <div class="Info">
+            Cube Map. Texture by <a href="http://www.humus.name" target="_blank">Humus</a>
+            <div id="dropdown">
+                <label for="zoom-style">Zoom Style:</label>
+                <select name="zoom-style" id="zoom-style">
+                    <option value="dolly">Dolly</option>
+                    <option value="fov">FOV</option>
+                </select>
+            </div>
+        </div>
         <script type="module">
             import { Renderer, Camera, Transform, Texture, Program, Geometry, Mesh, Box, Orbit } from '../src/index.mjs';
 
@@ -60,6 +69,10 @@
                 camera.position.set(-2, 1, -3);
 
                 const controls = new Orbit(camera);
+
+                document.querySelector('#dropdown').addEventListener('change', ({ target: { value } }) => {
+                    controls.zoomStyle = value;
+                });
 
                 function resize() {
                     renderer.setSize(window.innerWidth, window.innerHeight);

--- a/examples/orbit-controls.html
+++ b/examples/orbit-controls.html
@@ -13,7 +13,17 @@
         <link href="assets/main.css" rel="stylesheet" />
     </head>
     <body>
-        <div class="Info">Orbit Controls. Model by Google Poly.</div>
+        <div class="Info">
+            Orbit Controls. Model by Google Poly.
+            <div id="dropdown">
+                <label for="zoom-style">Zoom Style:</label>
+                <select name="zoom-style" id="zoom-style">
+                    <option value="dolly">Dolly</option>
+                    <option value="fov">FOV</option>
+                </select>
+            </div>
+        </div>
+
         <script type="module">
             import { Renderer, Camera, Transform, Texture, Program, Geometry, Mesh, Vec3, Orbit } from '../src/index.mjs';
 
@@ -71,6 +81,10 @@
                     target: new Vec3(0, 0.7, 0),
                 });
 
+                document.querySelector('#dropdown').addEventListener('change', ({ target: { value } }) => {
+                    controls.zoomStyle = value;
+                });
+
                 function resize() {
                     renderer.setSize(window.innerWidth, window.innerHeight);
                     camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
@@ -94,6 +108,7 @@
                     cullFace: null,
                 });
 
+                let mesh;
                 loadModel();
                 async function loadModel() {
                     const data = await (await fetch(`assets/macaw.json`)).json();
@@ -109,7 +124,7 @@
                 }
 
                 requestAnimationFrame(update);
-                function update() {
+                function update(t) {
                     requestAnimationFrame(update);
 
                     // Need to update controls every frame

--- a/src/extras/Orbit.js
+++ b/src/extras/Orbit.js
@@ -25,6 +25,7 @@ export function Orbit(
         autoRotateSpeed = 1.0,
         enableZoom = true,
         zoomSpeed = 1,
+        zoomStyle = 'dolly',
         enablePan = true,
         panSpeed = 0.1,
         minPolarAngle = 0,
@@ -37,6 +38,7 @@ export function Orbit(
 ) {
     this.enabled = enabled;
     this.target = target;
+    this.zoomStyle = zoomStyle;
 
     // Catch attempts to disable - set to 1 so has no effect
     ease = ease || 1;
@@ -146,9 +148,14 @@ export function Orbit(
         panUp((2 * deltaY * targetDistance) / el.clientHeight, object.matrix);
     };
 
-    function dolly(dollyScale) {
-        sphericalDelta.radius /= dollyScale;
-    }
+    const dolly = (dollyScale) => {
+        if (this.zoomStyle === 'dolly') sphericalDelta.radius /= dollyScale;
+        else {
+            object.fov /= dollyScale;
+            if (object.type === 'orthographic') object.orthographic();
+            else object.perspective();
+        }
+    };
 
     function handleAutoRotate() {
         const angle = ((2 * Math.PI) / 60 / 60) * autoRotateSpeed;


### PR DESCRIPTION
## Fixes #107 

Added option `zoomStyle` to the Orbit class. Defaults to `"dolly"` and uses Dolly zoom, else uses fov zooming.

https://github.com/FarazzShaikh/ogl/blob/1c329c3210b2169c54bd1eb0f253f49b678e4ce6/src/extras/Orbit.js#L151-L158

Also updated the "Orbit Controls" and "Cube Map" example to include a dropdown to select the zoom type.
