### PR TITLE
add RenderTarget.setSize method

### DIFF
--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -106,4 +106,45 @@ export class RenderTarget {
 
         this.gl.bindFramebuffer(this.target, null);
     }
+
+    setSize(width, height) {
+        if (this.width === width && this.height === height) return;
+
+        this.width = width;
+        this.height = height;
+        this.gl.bindFramebuffer(this.target, this.buffer);
+
+        for (let i = 0; i < this.textures.length; i++) {
+            this.textures[i].width = width;
+            this.textures[i].height = height;
+            this.textures[i].needsUpdate = true;
+            this.textures[i].update();
+            this.gl.framebufferTexture2D(this.target, this.gl.COLOR_ATTACHMENT0 + i, this.gl.TEXTURE_2D, this.textures[i].texture, 0 /* level */);
+        }
+
+        if (this.depthTexture) {
+            this.depthTexture.width = width;
+            this.depthTexture.height = height;
+            this.depthTexture.needsUpdate = true;
+            this.depthTexture.update();
+            this.gl.framebufferTexture2D(this.target, this.gl.DEPTH_ATTACHMENT, this.gl.TEXTURE_2D, this.depthTexture.texture, 0 /* level */);
+        } else {
+            if (this.depthBuffer) {
+                this.gl.bindRenderbuffer(this.gl.RENDERBUFFER, this.depthBuffer);
+                this.gl.renderbufferStorage(this.gl.RENDERBUFFER, this.gl.DEPTH_COMPONENT16, width, height);
+            }
+
+            if (this.stencilBuffer) {
+                this.gl.bindRenderbuffer(this.gl.RENDERBUFFER, this.stencilBuffer);
+                this.gl.renderbufferStorage(this.gl.RENDERBUFFER, this.gl.STENCIL_INDEX8, width, height);
+            }
+
+            if (this.depthStencilBuffer) {
+                this.gl.bindRenderbuffer(this.gl.RENDERBUFFER, this.depthStencilBuffer);
+                this.gl.renderbufferStorage(this.gl.RENDERBUFFER, this.gl.DEPTH_STENCIL, width, height);
+            }
+        }
+
+        this.gl.bindFramebuffer(this.target, null);
+    }
 }


### PR DESCRIPTION
Hey mate! 🤙

Here's a proposal for adding a `.setSize(width, height)` method to the RenderTarget.
It's been raised before in #91 but I don't think the suggested fix (recreating RenderTarget) is convenient in a medium+ scale application where the pipeline might be passing references of RenderTargets to different places, making these references lost on resize.

I also checked a bunch of small and big gl frameworks (three, babylon, pixi, lumagl, twgl, medium, etc) and they all have a similar method on their respective RenderTarget implementation, so I think it's not absurd for devs to expect such a method.

If you're interested in this PR, maybe I can update the examples that are currently recreating RenderTarget so that they use `.setSize` instead?

Happy to hear your thoughts. Cheers!