### PR TITLE
Simple Fresnel example improvements

### DIFF
--- a/examples/fresnel.html
+++ b/examples/fresnel.html
@@ -16,7 +16,7 @@
     <body>
         <div class="Info">Simple Fresnel Shader</div>
         <script type="module">
-            import { Renderer, Camera, Transform, Program, Mesh, Sphere, Color } from '../src/index.mjs';
+            import { Renderer, Camera, Orbit, Transform, Program, Torus, Mesh, Color } from '../src/index.mjs';
 
             const params = {
                 backgroundColor: new Color('#B6D8F2'),
@@ -24,6 +24,49 @@
                 fresnelColor: new Color('#F7F6CF'),
                 fresnelFactor: 1.5,
             };
+
+            const vertex = /* glsl */ `
+                attribute vec3 position;
+                attribute vec3 normal;
+
+                uniform mat4 modelMatrix;
+                uniform mat4 modelViewMatrix;
+                uniform mat4 projectionMatrix;
+                uniform vec3 cameraPosition;
+
+                varying vec3 vWorldNormal;
+                varying vec3 vViewDirection;
+
+                void main() {
+                    vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+                    vWorldNormal = normalize(modelMatrix * vec4(normal, 0.0)).xyz;
+                    vViewDirection = normalize(cameraPosition - worldPosition.xyz);
+
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `;
+
+            const fragment = /* glsl */ `
+                precision highp float;
+
+                uniform vec3 uBaseColor;
+                uniform vec3 uFresnelColor;
+                uniform float uFresnelPower;
+
+                varying vec3 vWorldNormal;
+                varying vec3 vViewDirection;
+
+                void main() {
+                    float fresnelFactor = abs(dot(vViewDirection, vWorldNormal));
+                    float inversefresnelFactor = 1.0 - fresnelFactor;
+
+                    // Shaping function
+                    fresnelFactor = pow(fresnelFactor, uFresnelPower);
+                    inversefresnelFactor = pow(inversefresnelFactor, uFresnelPower);
+
+                    gl_FragColor = vec4(fresnelFactor * uBaseColor + inversefresnelFactor * uFresnelColor, 1.0);
+                }
+            `;
 
             {
                 const renderer = new Renderer({ dpr: 2 });
@@ -43,64 +86,12 @@
                 resize();
 
                 const scene = new Transform();
-
-                const sphereGeometry = new Sphere(gl, {
-                    radius: 1,
-                    widthSegments: 128,
-                });
-
-                const vertex = /* glsl */ `
-                    attribute vec3 position;
-                    attribute vec2 uv;
-                    attribute vec3 normal;
-
-                    uniform mat4 modelViewMatrix;
-                    uniform mat4 projectionMatrix;
-                    uniform mat3 normalMatrix;
-
-                    varying vec2 vUv;
-                    varying vec3 vNormal;
-                    varying vec3 vPosition;
-
-                    void main() {					
-                        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-
-                        vPosition = position;
-                        vUv = uv;
-                        vNormal = normalMatrix * normal;
-                    }
-                `;
-
-                const fragment = /* glsl */ `
-                    precision highp float;
-
-                    varying vec2 vUv;
-                    varying vec3 vNormal;
-                    varying vec3 vPosition;
-
-                    uniform vec3 fresnelColor;
-                    uniform vec3 baseColor;
-                    uniform float powerOfFactor;
-                    uniform vec3 cameraPosition;
-
-                    void main() {
-                        vec3 viewDirection = normalize(cameraPosition - vPosition.xyz);
-                        float fresnelFactor = dot(viewDirection, normalize(vNormal));
-                        
-                        float inversefresnelFactor = clamp(1. - fresnelFactor, 0., 1.);
-                        
-                        // Shaping function
-                        fresnelFactor = pow(fresnelFactor, powerOfFactor);
-                        inversefresnelFactor = pow(inversefresnelFactor, powerOfFactor);
-
-                        gl_FragColor = vec4(fresnelFactor * baseColor + inversefresnelFactor * fresnelColor, 1.);
-                    }
-                `;
+                const controls = new Orbit(camera);
 
                 const uniforms = {
-                    fresnelColor: { value: params.fresnelColor },
-                    baseColor: { value: params.baseColor },
-                    powerOfFactor: { value: params.fresnelFactor },
+                    uBaseColor: { value: params.baseColor },
+                    uFresnelColor: { value: params.fresnelColor },
+                    uFresnelPower: { value: params.fresnelFactor },
                 };
 
                 const program = new Program(gl, {
@@ -109,14 +100,22 @@
                     uniforms: uniforms,
                 });
 
-                const sphere = new Mesh(gl, { geometry: sphereGeometry, program });
-                sphere.setParent(scene);
+                const torusGeometry = new Torus(gl, {
+                    radius: 1,
+                    tube: 0.4,
+                    radialSegments: 32,
+                    tubularSegments: 64,
+                });
+
+                const torus = new Mesh(gl, { geometry: torusGeometry, program });
+                torus.setParent(scene);
 
                 requestAnimationFrame(update);
                 function update() {
                     requestAnimationFrame(update);
-                    sphere.rotation.x += 0.01;
-                    sphere.rotation.z += 0.02;
+                    torus.rotation.x += 0.01;
+
+                    controls.update();
 
                     renderer.render({ scene, camera });
                 }


### PR DESCRIPTION
- Setting view direction in the vertex shader.
- Updated the Fresnel function to use `abs()` instead and applied before the inverse so the shaping function values are accurate.
- Added Torus and Orbit controls from the Torus example, with double the segments for a smooth look.
- House cleaning, rearranged code based on the Torus example, uniform naming convention and linted.
- 🙌