### PR TITLE
feat(Renderer): add `setScissor` method

### DIFF
--- a/src/core/Renderer.js
+++ b/src/core/Renderer.js
@@ -125,6 +125,11 @@ export class Renderer {
         this.gl.viewport(0, 0, width, height);
     }
 
+    setScissor(width, height, x = 0, y = 0) {
+        this.enable(this.gl.SCISSOR_TEST);
+        this.gl.scissor(x, y, width, height);
+    }
+
     enable(id) {
         if (this.state[id] === true) return;
         this.gl.enable(id);

--- a/src/core/Renderer.js
+++ b/src/core/Renderer.js
@@ -126,7 +126,6 @@ export class Renderer {
     }
 
     setScissor(width, height, x = 0, y = 0) {
-        this.enable(this.gl.SCISSOR_TEST);
         this.gl.scissor(x, y, width, height);
     }
 


### PR DESCRIPTION
Adds support for SCISSOR_TEST as described in #109. This will unblock #77 to create a WebXR renderer (or just VR if code paths are introduced for layers/AR features).

Should we keep track of where the scissor region is set in state? I'm not sure if `state.viewport` would be appropriate, but I'm leaning towards `state.scissor` if needed.