### PR TITLE
feat(Renderer): accept optional x & y in `setViewport`

### DIFF
--- a/src/core/Renderer.js
+++ b/src/core/Renderer.js
@@ -118,11 +118,11 @@ export class Renderer {
         });
     }
 
-    setViewport(width, height) {
+    setViewport(width, height, x = 0, y = 0) {
         if (this.state.viewport.width === width && this.state.viewport.height === height) return;
         this.state.viewport.width = width;
         this.state.viewport.height = height;
-        this.gl.viewport(0, 0, width, height);
+        this.gl.viewport(x, y, width, height);
     }
 
     enable(id) {

--- a/src/core/Renderer.js
+++ b/src/core/Renderer.js
@@ -63,7 +63,7 @@ export class Renderer {
         this.state.flipY = false;
         this.state.unpackAlignment = 4;
         this.state.framebuffer = null;
-        this.state.viewport = { width: null, height: null };
+        this.state.viewport = { x: 0, y: 0, width: null, height: null };
         this.state.textureUnits = [];
         this.state.activeTextureUnit = 0;
         this.state.boundBuffer = null;
@@ -122,6 +122,8 @@ export class Renderer {
         if (this.state.viewport.width === width && this.state.viewport.height === height) return;
         this.state.viewport.width = width;
         this.state.viewport.height = height;
+        this.state.viewport.x = x;
+        this.state.viewport.y = y;
         this.gl.viewport(x, y, width, height);
     }
 


### PR DESCRIPTION
Mirrors the API in #119 where `x` and `y` are optional arguments.