### PR TITLE
Update menu item to highlight

### DIFF
--- a/examples/assets/main.css
+++ b/examples/assets/main.css
@@ -108,6 +108,13 @@ body {
     padding-left: 30px;
     display: block;
 }
+.Example.active {
+    background-color: #3dd6ff;
+    margin: 0px -40px 0px -20px;
+    padding: 5px 0px 5px 50px;
+    font-weight: bold;
+    color: white;
+}
 div.Example {
     opacity: 0.2;
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -132,7 +132,7 @@
 
                 // Highlight and update others
                 exampleLinks.forEach((link) => {
-                    if (link === e) link.classList.add('active');
+                    if (link === e.target) link.classList.add('active');
                     else link.classList.remove('active');
                 });
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -108,7 +108,7 @@
             if (loadQuery[1]) {
                 iFrame.src = loadQuery[1];
                 sourceLink.href = sourcePath + loadQuery[1];
-                highlight(sourceLink.href);
+                highlight(loadQuery[1]);
             } else {
                 // choose random example to show if none linked
                 let target = exampleLinks[Math.floor(Math.random() * exampleLinks.length)];
@@ -130,7 +130,7 @@
 
                 iFrame.src = e.target.href;
                 sourceLink.href = sourcePath + src;
-                highlight(sourceLink.href);
+                highlight(src);
 
                 // Update search query
                 history.pushState(null, null, `${location.origin}${location.pathname}?src=${src}`);
@@ -138,9 +138,10 @@
             }
 
             // Highlight and update others
-            function highlight(href) {
+            function highlight(src) {
                 exampleLinks.forEach((link) => {
-                    if (link.href === href) link.classList.add('active');
+                    let linkSrc = link.href.split('examples/')[1];
+                    if (src === linkSrc) link.classList.add('active');
                     else link.classList.remove('active');
                 });
             }

--- a/examples/index.html
+++ b/examples/index.html
@@ -130,6 +130,12 @@
                 iFrame.src = e.target.href;
                 sourceLink.href = sourcePath + src;
 
+                // Highlight and update others
+                exampleLinks.forEach((link) => {
+                    if (link === e) link.classList.add('active');
+                    else link.classList.remove('active');
+                });
+
                 // Update search query
                 history.pushState(null, null, `${location.origin}${location.pathname}?src=${src}`);
                 e.preventDefault && e.preventDefault();

--- a/examples/index.html
+++ b/examples/index.html
@@ -108,6 +108,7 @@
             if (loadQuery[1]) {
                 iFrame.src = loadQuery[1];
                 sourceLink.href = sourcePath + loadQuery[1];
+                highlight(sourceLink.href);
             } else {
                 // choose random example to show if none linked
                 let target = exampleLinks[Math.floor(Math.random() * exampleLinks.length)];
@@ -129,16 +130,19 @@
 
                 iFrame.src = e.target.href;
                 sourceLink.href = sourcePath + src;
-
-                // Highlight and update others
-                exampleLinks.forEach((link) => {
-                    if (link === e.target) link.classList.add('active');
-                    else link.classList.remove('active');
-                });
+                highlight(sourceLink.href);
 
                 // Update search query
                 history.pushState(null, null, `${location.origin}${location.pathname}?src=${src}`);
                 e.preventDefault && e.preventDefault();
+            }
+
+            // Highlight and update others
+            function highlight(href) {
+                exampleLinks.forEach((link) => {
+                    if (link.href === href) link.classList.add('active');
+                    else link.classList.remove('active');
+                });
             }
         </script>
     </body>


### PR DESCRIPTION
First, I'd say to thank for this repository.

This PR is for highlighting to display what example I looking at. When choose some text(menu), highlight it and toggle it.

well.. For me, the reason for need is, it's hard to flip through all examples on list.

![image](https://user-images.githubusercontent.com/9527681/147409438-327bd26c-642d-45a0-b7c0-6af5a9dd2e53.png)

DEMO is here, in github page from my forked repository: https://www.joonas.io/ogl/examples/