### PR TITLE
feat: Allow to use depth-only pass by setting colorMask to false

### DIFF
--- a/src/core/Program.js
+++ b/src/core/Program.js
@@ -20,6 +20,7 @@ export class Program {
             frontFace = gl.CCW,
             depthTest = true,
             depthWrite = true,
+            colorWrite = true,
             depthFunc = gl.LESS,
         } = {}
     ) {
@@ -38,6 +39,8 @@ export class Program {
         this.depthTest = depthTest;
         this.depthWrite = depthWrite;
         this.depthFunc = depthFunc;
+        this.colorWrite = colorWrite;
+
         this.blendFunc = {};
         this.blendEquation = {};
 
@@ -141,6 +144,7 @@ export class Program {
         if (this.blendFunc.src)
             this.gl.renderer.setBlendFunc(this.blendFunc.src, this.blendFunc.dst, this.blendFunc.srcAlpha, this.blendFunc.dstAlpha);
         this.gl.renderer.setBlendEquation(this.blendEquation.modeRGB, this.blendEquation.modeAlpha);
+        this.gl.renderer.setColorWrite(this.colorWrite);
     }
 
     use({ flipFaces = false } = {}) {

--- a/src/core/Renderer.js
+++ b/src/core/Renderer.js
@@ -68,6 +68,7 @@ export class Renderer {
         this.state.activeTextureUnit = 0;
         this.state.boundBuffer = null;
         this.state.uniformLocations = new Map();
+        this.state.colorWrite = true;
 
         // store requested extensions
         this.extensions = {};
@@ -196,6 +197,12 @@ export class Renderer {
         if (this.state.depthFunc === value) return;
         this.state.depthFunc = value;
         this.gl.depthFunc(value);
+    }
+    
+    setColorWrite(value) {
+        if (this.state.colorWrite === value) return;
+        this.state.colorWrite = value;
+        this.gl.colorMask(value, value, value, value);
     }
 
     activeTexture(value) {


### PR DESCRIPTION
This is feature required when there are semi-transparent complex object with special depth mask Or when needed to use a blend composition with special depth mask (WebXR Layers)