### PR TITLE
Text per-character index correction

### DIFF
--- a/src/extras/Text.js
+++ b/src/extras/Text.js
@@ -47,7 +47,7 @@ export function Text({
 
         // Set values for buffers that don't require calculation
         for (let i = 0; i < numChars; i++) {
-            buffers.id[i] = i;
+            buffers.id.set([i, i, i, i], i * 4);
             buffers.index.set([i * 4, i * 4 + 2, i * 4 + 1, i * 4 + 1, i * 4 + 2, i * 4 + 3], i * 6);
         }
 


### PR DESCRIPTION
When using the per-character index noticed that the buffer didn't have the values expected, shouldn't that buffer have a length of 4 for the quad vertices of each character?

Or at-least that's how I was using it. 😊