### PR TITLE
[enhancement]  Isolate ProgramData from Program for allow reuse GL Program instance

### DIFF
--- a/examples/high-mesh-count.html
+++ b/examples/high-mesh-count.html
@@ -42,11 +42,13 @@
                 precision highp float;
     
                 varying vec3 vNormal;
+
+                uniform vec3 uColor;
     
                 void main() {
                     vec3 normal = normalize(vNormal);
                     float lighting = dot(normal, normalize(vec3(-0.3, 0.8, 0.6)));
-                    gl_FragColor.rgb = vec3(0.2, 0.8, 1.0) + lighting * 0.1;
+                    gl_FragColor.rgb = uColor + lighting * 0.1;
                     gl_FragColor.a = 1.0;
                 }
             `;
@@ -71,14 +73,25 @@
                 // Create base geometry
                 const cubeGeometry = new Box(gl);
     
-                // Using the shader from the base primitive example
-                const program = new Program(gl, {
-                    vertex,
-                    fragment,
-                });
-    
                 // mesh container
                 let meshes = [];
+
+                const colorPrograms = {};
+                const getColorProgram = () => {
+                    const color = [
+                        ((Math.random() * 10) | 0) / 10,
+                        ((Math.random() * 10) | 0) / 10,
+                        ((Math.random() * 10) | 0) / 10,
+                    ];
+
+                    const key = color.join(',');
+
+                    return colorPrograms[key] || (colorPrograms[key] = new Program(gl, {
+                        vertex,
+                        fragment,
+                        uniforms: { uColor: { value: color } } 
+                    }));
+                };
     
                 window.setMeshCount = function setMeshCount(count) {
     
@@ -91,7 +104,7 @@
     
                     // create our meshes according to input
                     for (let i = 0; i < count; ++i){
-                        let mesh = new Mesh(gl, {geometry: cubeGeometry, program});
+                        let mesh = new Mesh(gl, {geometry: cubeGeometry, program: getColorProgram()});
     
                         // position meshes in a random position between -100 / +100 in each dimension
                         mesh.position.set(

--- a/src/core/Program.js
+++ b/src/core/Program.js
@@ -114,6 +114,9 @@ export class Program {
     use({ flipFaces = false } = {}) {
         let textureUnit = -1;
 
+        /**
+         * @type {WebGL2RenderingContext}
+         */
         const gl = this.gl;
         const uniforms = this.uniforms;
         const programData = this.programData;

--- a/src/core/Program.js
+++ b/src/core/Program.js
@@ -49,7 +49,7 @@ export class Program {
             else this.setBlendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
         }
 
-        this.programData = ProgramData.create(gl, vertex, fragment);
+        this.programData = ProgramData.create(gl, { vertex, fragment });
     }
 
     /**
@@ -116,14 +116,14 @@ export class Program {
 
         const gl = this.gl;
         const uniforms = this.uniforms;
-        const program = this.programData.program;
+        const programData = this.programData;
         const uniformLocations = this.programData.uniformLocations;
-        const programActive = gl.renderer.state.currentProgram === program.id;
+        const programActive = gl.renderer.state.currentProgram === programData.id;
 
         // Avoid gl call if program already in use
         if (!programActive) {
-            gl.useProgram(program.program);
-            gl.renderer.state.currentProgram = program.id;
+            gl.useProgram(programData.program);
+            gl.renderer.state.currentProgram = programData.id;
         }
 
         // Set only the active uniforms found in the shader
@@ -235,14 +235,6 @@ function setUniform(gl, type, location, value) {
         case 35676:
             return gl.uniformMatrix4fv(location, false, value); // FLOAT_MAT4
     }
-}
-
-function addLineNumbers(string) {
-    let lines = string.split('\n');
-    for (let i = 0; i < lines.length; i++) {
-        lines[i] = i + 1 + ': ' + lines[i];
-    }
-    return lines.join('\n');
 }
 
 function flatten(a) {

--- a/src/core/ProgramData.js
+++ b/src/core/ProgramData.js
@@ -19,14 +19,11 @@ export class ProgramData {
      * @returns 
      */
     static create (gl, { vertex, fragment }) {
-        const key = vertex + fragment;
-        const program = this.CACHE.get(key) || new ProgramData(gl, { vertex, fragment });
+        const program = this.CACHE.get(vertex + fragment) || new ProgramData(gl, { vertex, fragment });
 
         program.usage ++;
 
-        this.CACHE.set(key, program);
-
-        return program.compile();
+        return program;
     }
 
     constructor(
@@ -72,6 +69,10 @@ export class ProgramData {
         this.attributeOrder = '';
 
         this.id = (1 << 8) + ID++;
+
+        ProgramData.CACHE.set(this.vertex + this.fragment, program);
+
+        this.compile();
     }
 
     compile () {

--- a/src/core/ProgramData.js
+++ b/src/core/ProgramData.js
@@ -113,6 +113,8 @@ export class ProgramData {
 
         this.id = (1 << 8) + ID++;
 
+        this.usage = 0;
+
         this.compile();
     }
 
@@ -169,6 +171,9 @@ export class ProgramData {
         gl.deleteShader(fragmentShader);
 
         this.program = program;
+        // can be recompiled after loose
+        this.uniformLocations.clear();
+        this.attributeLocations.clear();
 
         // Get active uniform locations
         let numUniforms = gl.getProgramParameter(this.program, gl.ACTIVE_UNIFORMS);

--- a/src/core/ProgramData.js
+++ b/src/core/ProgramData.js
@@ -1,0 +1,169 @@
+/**
+ * Internal program data class, storing shader data for each Program instance
+ * Used for reusing a native program for different Ogl programs without re-use of base shader.
+ */
+
+let ID = 0;
+
+export class ProgramData {
+    /**
+     * @type {Map<string, ProgramData>}
+     */
+    static CACHE = new Map();
+
+    /**
+     * Create or return already existed program data for current shaders source
+     * @param {WebGLRenderingContext | WebGL2RenderingContext} gl 
+     * @param {string} vertex 
+     * @param {string} fragment 
+     */
+    static create (gl, vertex, fragment) {
+        const key = vertex + fragment;
+        const program = this.CACHE.get(key) || new ProgramData(gl, vertex + fragment);
+
+        program.usage ++;
+
+        this.CACHE.set(key, program);
+
+        return program.compile();
+    }
+
+    static remove ()
+
+    constructor(
+        gl,
+        {
+            vertex,
+            fragment,
+        } = {}
+    ) {
+        /**
+         * @type {WebGLRenderingContext | WebGL2RenderingContext}
+         */
+        this.gl = gl;
+
+        /**
+         * @type {string}
+         */
+        this.vertex = vertex;
+
+        /**
+         * @type {string}
+         */
+        this.fragment = fragment;
+
+        /**
+         * @type {WebGLProgram}
+         */
+        this.program = null;
+
+        /**
+         * @type {Map<WebGLActiveInfo, WebGLUniformLocation>}
+         */
+        this.uniformLocations = new Map();
+
+        /**
+         * @type {Map<WebGLActiveInfo, number>}
+         */
+        this.attributeLocations = new Map()
+
+        /**
+         * @type {string}
+         */
+        this.attributeOrder = '';
+
+        this.id = (1 << 8) + ID++;
+    }
+
+    compile () {
+        if (this.program) {
+            return this;
+        }
+
+        const gl = this.gl;
+        const vertex = this.vertex;
+        const fragment = this.fragment;
+
+        // compile vertex shader and log errors
+        const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(vertexShader, vertex);
+        gl.compileShader(vertexShader);
+        if (gl.getShaderInfoLog(vertexShader) !== '') {
+            console.warn(`${gl.getShaderInfoLog(vertexShader)}\nVertex Shader\n${addLineNumbers(vertex)}`);
+        }
+
+        // compile fragment shader and log errors
+        const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(fragmentShader, fragment);
+        gl.compileShader(fragmentShader);
+        if (gl.getShaderInfoLog(fragmentShader) !== '') {
+            console.warn(`${gl.getShaderInfoLog(fragmentShader)}\nFragment Shader\n${addLineNumbers(fragment)}`);
+        }
+
+        // compile program and log errors
+        this.program = gl.createProgram();
+        gl.attachShader(this.program, vertexShader);
+        gl.attachShader(this.program, fragmentShader);
+        gl.linkProgram(this.program);
+        if (!gl.getProgramParameter(this.program, gl.LINK_STATUS)) {
+            console.warn(gl.getProgramInfoLog(this.program));
+            return this;
+        }
+
+        // Remove shader once linked
+        gl.deleteShader(vertexShader);
+        gl.deleteShader(fragmentShader);
+
+        // Get active uniform locations
+        let numUniforms = gl.getProgramParameter(this.program, gl.ACTIVE_UNIFORMS);
+        for (let uIndex = 0; uIndex < numUniforms; uIndex++) {
+            let uniform = gl.getActiveUniform(this.program, uIndex);
+            this.uniformLocations.set(uniform, gl.getUniformLocation(this.program, uniform.name));
+
+            // split uniforms' names to separate array and struct declarations
+            const split = uniform.name.match(/(\w+)/g);
+
+            uniform.uniformName = split[0];
+
+            if (split.length === 3) {
+                uniform.isStructArray = true;
+                uniform.structIndex = Number(split[1]);
+                uniform.structProperty = split[2];
+            } else if (split.length === 2 && isNaN(Number(split[1]))) {
+                uniform.isStruct = true;
+                uniform.structProperty = split[1];
+            }
+        }
+
+        // Get active attribute locations
+        const locations = [];
+        const numAttribs = gl.getProgramParameter(this.program, gl.ACTIVE_ATTRIBUTES);
+        for (let aIndex = 0; aIndex < numAttribs; aIndex++) {
+            const attribute = gl.getActiveAttrib(this.program, aIndex);
+            const location = gl.getAttribLocation(this.program, attribute.name);
+            locations[location] = attribute.name;
+            this.attributeLocations.set(attribute, location);
+        }
+
+        this.attributeOrder = locations.join('');
+
+        return this;
+    }
+
+    remove() {
+        this.usage--;
+
+        if (this.usage <= 0 && this.program) {
+            this.gl.deleteProgram(this.program);
+
+            ProgramData.CACHE.remove(this.vertex + this.fragment);
+        }
+
+        this.id = -1;
+        this.fragment = null;
+        this.vertex = null;
+        this.attributeLocations.clear();
+        this.attributeOrder = '';
+        this.uniformLocations.clear();
+    }
+}

--- a/src/core/ProgramData.js
+++ b/src/core/ProgramData.js
@@ -155,7 +155,7 @@ export class ProgramData {
         if (this.usage <= 0 && this.program) {
             this.gl.deleteProgram(this.program);
 
-            ProgramData.CACHE.remove(this.vertex + this.fragment);
+            ProgramData.CACHE.delete(this.vertex + this.fragment);
         }
 
         this.id = -1;

--- a/src/core/ProgramData.js
+++ b/src/core/ProgramData.js
@@ -11,7 +11,6 @@ export class ProgramData {
      */
     static CACHE = new Map();
 
-
     /**
      * Create or return already existed program data for current shaders source
      * @param { WebGLRenderingContext | WebGL2RenderingContext } gl 
@@ -70,7 +69,7 @@ export class ProgramData {
 
         this.id = (1 << 8) + ID++;
 
-        ProgramData.CACHE.set(this.vertex + this.fragment, program);
+        ProgramData.CACHE.set(this.vertex + this.fragment, this);
 
         this.compile();
     }

--- a/src/core/ProgramData.js
+++ b/src/core/ProgramData.js
@@ -11,15 +11,16 @@ export class ProgramData {
      */
     static CACHE = new Map();
 
+
     /**
      * Create or return already existed program data for current shaders source
-     * @param {WebGLRenderingContext | WebGL2RenderingContext} gl 
-     * @param {string} vertex 
-     * @param {string} fragment 
+     * @param { WebGLRenderingContext | WebGL2RenderingContext } gl 
+     * @param {{ vertex: string, fragment: string}} param1 
+     * @returns 
      */
-    static create (gl, vertex, fragment) {
+    static create (gl, { vertex, fragment }) {
         const key = vertex + fragment;
-        const program = this.CACHE.get(key) || new ProgramData(gl, vertex + fragment);
+        const program = this.CACHE.get(key) || new ProgramData(gl, { vertex, fragment });
 
         program.usage ++;
 
@@ -28,14 +29,12 @@ export class ProgramData {
         return program.compile();
     }
 
-    static remove ()
-
     constructor(
         gl,
         {
             vertex,
             fragment,
-        } = {}
+        }
     ) {
         /**
          * @type {WebGLRenderingContext | WebGL2RenderingContext}
@@ -166,4 +165,12 @@ export class ProgramData {
         this.attributeOrder = '';
         this.uniformLocations.clear();
     }
+}
+
+function addLineNumbers(string) {
+    let lines = string.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+        lines[i] = i + 1 + ': ' + lines[i];
+    }
+    return lines.join('\n');
 }


### PR DESCRIPTION
Why need this?

Sometimes needs to use multiple instance for same shader code, but with different uniforms (textures, color, any other data) which can't passed by attributes;

This PR split Program and ProgramData, now ProgramData store only info that needed for program usage.

Program now is like Material - store instance-specific values like uniforms or state.
You can spawn a lot of Programs from same shader code that with different uniform and state combination (see updated example).

Other benefits - we can easy change a ProgramData in program without update program reference in each mesh instance.
When this can be used? For example, when need use different shaders for each pass, like ShadowMap pass. You can change  programData field to specific ProgramData instance for specific Program and shader will be replaced for each references automatically, but uniform and state wont  changed.
