### PR TITLE
fix: properly label targets for node compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ogl",
     "version": "0.0.93",
     "description": "WebGL Library",
-    "main": "src/index.mjs",
+    "module": "src/index.mjs",
     "sideEffects": false,
     "directories": {
         "example": "examples"


### PR DESCRIPTION
Properly labels OGL's ES module target as a module for Node compat. main will imply it is commonjs and fail resolution (related: [Node .mjs extension and modules](https://nodejs.org/api/modules.html#the-mjs-extension)).

For those that run into this problem, a more complete fix is outlined in https://github.com/pmndrs/react-ogl#ogl-issues-with-ssrnode.