### PR TITLE
Add copy and clone methods in Program class

### DIFF
--- a/src/core/Program.js
+++ b/src/core/Program.js
@@ -148,6 +148,51 @@ export class Program {
     remove() {
         this.gl.deleteProgram(this.program);
     }
+
+    copy(source) {
+        if (this.gl !== source.gl) {
+            throw new Error('Failed to clone programs that don`t belong to the same WebGLRenderingContext');
+        }
+
+        this.id = ID++;
+
+        // Copy program state
+        this.transparent = source.transparent;
+        this.cullFace = source.cullFace;
+        this.frontFace = source.frontFace;
+        this.depthTest = source.depthTest;
+        this.depthWrite = source.depthWrite;
+        this.depthFunc = source.depthFunc;
+        this.blendFunc = { ...source.blendFunc };
+        this.blendEquation = { ...source.blendEquation };
+
+        this.program = source.program;
+        this.uniformLocations = source.uniformLocations;
+        this.attributeLocations = source.attributeLocations;
+        this.attributeOrder = source.attributeOrder;
+
+        this.uniforms = copyUniforms(source.uniforms);
+    }
+
+    clone() {
+        const clone = new Program(this.gl);
+        clone.copy(this);
+        return clone;
+    }
+}
+
+
+function copyUniforms(src) {
+    const srcEntries = Object.entries(src);
+    const dstEntries = srcEntries.map(([prop, obj]) => {
+        const cloned = obj.value?.clone ? 
+            { ...obj, value: obj.value.clone() } :
+            { ...obj  };
+
+        return [prop, cloned];
+    });
+
+    return Object.fromEntries(dstEntries);
 }
 
 function setUniform(gl, type, location, value) {

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -51,4 +51,8 @@ export class Color extends Array {
         this[2] = v[2];
         return this;
     }
+
+    clone() {
+        return new Color(this);
+    }
 }

--- a/src/math/Mat3.js
+++ b/src/math/Mat3.js
@@ -46,6 +46,12 @@ export class Mat3 extends Array {
         return this;
     }
 
+    clone() {
+        const clone = new Mat3();
+        clone.copy(this);
+        return clone;
+    }
+
     fromMatrix4(m) {
         Mat3Func.fromMat4(this, m);
         return this;

--- a/src/math/Mat4.js
+++ b/src/math/Mat4.js
@@ -95,6 +95,12 @@ export class Mat4 extends Array {
         return this;
     }
 
+    clone() {
+        const clone = new Mat4();
+        clone.copy(this);
+        return clone;
+    }
+
     fromPerspective({ fov, aspect, near, far } = {}) {
         Mat4Func.perspective(this, fov, aspect, near, far);
         return this;

--- a/src/math/Vec4.js
+++ b/src/math/Vec4.js
@@ -49,6 +49,10 @@ export class Vec4 extends Array {
         return this;
     }
 
+    clone() {
+        return new Vec4(this[0], this[1], this[2], this[3]);
+    }
+
     normalize() {
         Vec4Func.normalize(this, this);
         return this;


### PR DESCRIPTION
In some cases it is necessary to create programs with the same shader code but different uniforms (eg texture or color). The `clone` method creates a shallow copy of `Program` class. Copies all properties by reference except the uniforms. If uniform value has a `clone` method (eg `Vec2`, `Mat4`), it will be used, otherwise  (eg `Texture`) the value is copied by reference.

This PR also contains default vertex and fragment code to be able to create programs without vertex and/or fragment source code. Compiled default programs are cached given the `WebGLRenderingContext` because they are dependent on rendering context. The cache helps to quickly create an default  `WebGLProgram`, which will later be replaced by a `WebGLProgram` from another `Program`. It's needs for avoid recompilation/revalidation same shader default source code and very helpful for fast copy/clone methods.