### PR TITLE
Fix: instancing with gl_InstanceID

### DIFF
--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -119,6 +119,7 @@ export class Geometry {
     }
 
     setInstancedCount(value) {
+        this.isInstanced = value > 0;
         this.instancedCount = value;
     }
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -119,7 +119,6 @@ export class Geometry {
     }
 
     setInstancedCount(value) {
-        this.isInstanced = value > 0;
         this.instancedCount = value;
     }
 

--- a/src/core/Program.js
+++ b/src/core/Program.js
@@ -105,6 +105,8 @@ export class Program {
         for (let aIndex = 0; aIndex < numAttribs; aIndex++) {
             const attribute = gl.getActiveAttrib(this.program, aIndex);
             const location = gl.getAttribLocation(this.program, attribute.name);
+            if (location === -1) continue;
+
             locations[location] = attribute.name;
             this.attributeLocations.set(attribute, location);
         }


### PR DESCRIPTION
The `gl.getActiveAttrib` method returns some GLSL building variables (e.g. `gl_InstanceID`, `gl_VertexID`) as attributes with location == -1, so they need to be filtered out.
Also, to make it easier to use istancing draw without any additional attributes, the `setInstancedCount` method will automatically set the `isInstanced` flag depending on the given count value.