### PR TITLE
Fix mouse-flowmap exemple

### DIFF
--- a/examples/mouse-flowmap.html
+++ b/examples/mouse-flowmap.html
@@ -168,7 +168,7 @@
                     flowmap.mouse.copy(mouse);
 
                     // Ease velocity input, slower when fading out
-                    flowmap.velocity.lerp(velocity, velocity.len ? 0.5 : 0.1);
+                    flowmap.velocity.lerp(velocity, velocity.len() ? 0.5 : 0.1);
 
                     flowmap.update();
 


### PR DESCRIPTION
`flowmap.velocity.lerp(velocity, velocity.len ? 0.5 : 0.1);` => `flowmap.velocity.lerp(velocity, velocity.len() ? 0.5 : 0.1);`

`vec.len` is allways true