### PR TITLE
Add plane intersection to Raycast object

### DIFF
--- a/src/extras/Raycast.js
+++ b/src/extras/Raycast.js
@@ -255,6 +255,19 @@ export class Raycast {
         return hits;
     }
 
+    intersectPlane(plane, origin = this.origin, direction = this.direction) {
+        const xminp = tempVec3a;
+        xminp.sub(plane.origin, origin);
+
+        const a = xminp.dot(plane.normal);
+        const b = direction.dot(plane.normal);
+        // Assuming we don't want to count a ray parallel to the plane as intersecting
+        if (b == 0) return 0;
+        const delta = a / b;
+        if (delta <= 0) return 0;
+        return origin.add(direction.scale(delta));
+    }
+
     intersectSphere(sphere, origin = this.origin, direction = this.direction) {
         const ray = tempVec3c;
         ray.sub(sphere.center, origin);


### PR DESCRIPTION
This adds a method for the Raycast class to be able to intersect with planes. I tried to follow the style of the other intersection methods, let me know if anything doesn't look right! The math is the same as described here: https://math.stackexchange.com/questions/4402134/determining-plane-intersection-with-a-ray