### PR TITLE
TypeScript house cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ import { Renderer, Camera, Transform, Box, Program, Mesh } from 'ogl';
 
         mesh.rotation.y -= 0.04;
         mesh.rotation.x += 0.03;
+
         renderer.render({ scene, camera });
     }
 }

--- a/examples/anisotropic.html
+++ b/examples/anisotropic.html
@@ -23,7 +23,7 @@
         <div class="Info">Anisotropic</div>
         <div class="Info split"><span>Texture anisotropy: None</span> <span>Texture anisotropy: 16</span></div>
         <script type="module">
-            import { Renderer, Camera, Transform, Texture, Program, Geometry, Mesh, Plane } from '../src/index.js';
+            import { Renderer, Camera, Transform, Texture, Program, Mesh, Plane } from '../src/index.js';
 
             const vertex = /* glsl */ `
                 attribute vec2 uv;
@@ -46,13 +46,13 @@
                 uniform sampler2D tMap;
                 uniform sampler2D tMapA;
                 uniform float fSlide;
-                
+
                 varying vec2 vUv;
 
                 void main() {
                     vec3 tex = texture2D(tMap, vUv).rgb;
                     vec3 texA = texture2D(tMapA, vUv).rgb;
-                    
+
                     gl_FragColor.rgb = mix(tex, texA, step(fSlide, vUv.x)) + 0.1;
                     gl_FragColor.a = 1.0;
                 }
@@ -101,24 +101,21 @@
                     },
                 });
 
-                const mesh = new Mesh(gl, {
-                    geometry: geometry,
-                    program: program,
-                });
-
+                const mesh = new Mesh(gl, { geometry, program });
                 mesh.scale.set(1, 2, 1);
                 mesh.rotation.set(-1.5, 0, 0);
 
                 mesh.setParent(scene);
 
-                gl.canvas.addEventListener('mousemove', (event) => {
-                    const x = (2 * event.x) / gl.canvas.width;
+                gl.canvas.addEventListener('mousemove', (e) => {
+                    const x = (2 * e.x) / gl.canvas.width;
                     program.uniforms.fSlide.value = x;
                 });
 
                 requestAnimationFrame(update);
-                function update(t) {
+                function update() {
                     requestAnimationFrame(update);
+
                     renderer.render({ scene, camera });
                 }
             }

--- a/examples/assets/main.css
+++ b/examples/assets/main.css
@@ -48,7 +48,7 @@ a {
 @font-face {
     font-family: 'Raleway';
     src: url('fonts/raleway-regular-webfont.woff2') format('woff2'),
-        url('fonts/raleway-regular-webfont.woff') format('woff');
+         url('fonts/raleway-regular-webfont.woff') format('woff');
     font-weight: 400;
     font-style: normal;
 }
@@ -56,7 +56,7 @@ a {
 @font-face {
     font-family: 'Raleway';
     src: url('fonts/raleway-bold-webfont.woff2') format('woff2'),
-        url('fonts/raleway-bold-webfont.woff') format('woff');
+         url('fonts/raleway-bold-webfont.woff') format('woff');
     font-weight: 700;
     font-style: normal;
 }
@@ -159,7 +159,7 @@ div.Example {
     [data-hideSidebar] .Side {
         transform: translateX(-100%);
     }
-    
+
     [data-hideSidebar] .SideIcon {
         left: 0;
         transform: rotate(180deg);

--- a/examples/base-primitives.html
+++ b/examples/base-primitives.html
@@ -77,7 +77,7 @@
                     fragment,
 
                     // Don't cull faces so that plane is double sided - default is gl.BACK
-                    cullFace: null,
+                    cullFace: false,
                 });
 
                 const plane = new Mesh(gl, { geometry: planeGeometry, program });
@@ -99,13 +99,13 @@
                 requestAnimationFrame(update);
                 function update() {
                     requestAnimationFrame(update);
-                    controls.update();
 
                     plane.rotation.y -= 0.02;
                     sphere.rotation.y -= 0.03;
                     cube.rotation.y -= 0.04;
                     cylinder.rotation.y -= 0.02;
 
+                    controls.update();
                     renderer.render({ scene, camera });
                 }
             }

--- a/examples/compressed-textures.html
+++ b/examples/compressed-textures.html
@@ -15,7 +15,7 @@
     <body>
         <div class="Info">Compressed Textures.</div>
         <script type="module">
-            import { Renderer, Camera, Transform, Texture, Program, Mesh, Plane, Orbit, TextureLoader } from '../src/index.js';
+            import { Renderer, Camera, Transform, Program, Mesh, Plane, Orbit, TextureLoader } from '../src/index.js';
 
             const vertex = /* glsl */ `
                 attribute vec2 uv;
@@ -112,14 +112,14 @@
                     uniforms: {
                         tMap: { value: texture },
                     },
-                    cullFace: null,
+                    cullFace: false,
                 });
 
                 const mesh = new Mesh(gl, { geometry, program });
                 mesh.setParent(scene);
 
                 requestAnimationFrame(update);
-                function update(t) {
+                function update() {
                     requestAnimationFrame(update);
 
                     controls.update();

--- a/examples/cube-map.html
+++ b/examples/cube-map.html
@@ -24,7 +24,7 @@
             </div>
         </div>
         <script type="module">
-            import { Renderer, Camera, Transform, Texture, Program, Geometry, Mesh, Box, Orbit } from '../src/index.js';
+            import { Renderer, Camera, Transform, Texture, Program, Mesh, Box, Orbit } from '../src/index.js';
 
             const vertex = /* glsl */ `
                 attribute vec3 position;
@@ -36,7 +36,7 @@
 
                 void main() {
                     vDir = normalize(position);
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;
@@ -53,7 +53,7 @@
 
                     // sample function is textureCube rather than texture2D
                     vec3 tex = textureCube(tMap, vDir).rgb;
-                    
+
                     gl_FragColor.rgb = tex;
                     gl_FragColor.a = 1.0;
                 }
@@ -127,7 +127,7 @@
                     uniforms: {
                         tMap: { value: texture },
                     },
-                    cullFace: null,
+                    cullFace: false,
                 });
 
                 const skybox = new Mesh(gl, { geometry, program });
@@ -138,12 +138,12 @@
                 mesh.setParent(scene);
 
                 requestAnimationFrame(update);
-                function update(t) {
+                function update() {
                     requestAnimationFrame(update);
 
-                    controls.update();
-
                     mesh.rotation.y += 0.003;
+
+                    controls.update();
                     renderer.render({ scene, camera });
                 }
             }

--- a/examples/curves.html
+++ b/examples/curves.html
@@ -74,7 +74,7 @@
                     fragment,
 
                     // Don't cull faces so that plane is double sided - default is gl.BACK
-                    cullFace: null,
+                    cullFace: false,
                 });
 
                 const sphere = new Mesh(gl, { geometry: sphereGeometry, program });
@@ -117,8 +117,8 @@
                 });
 
                 for (let i = 0; i <= 60; i++) {
-                    const p = [polyline, polyline2, polyline3][i % 3];
-                    const mesh = new Mesh(gl, { geometry: p.geometry, program: p.program });
+                    const { geometry, program } = [polyline, polyline2, polyline3][i % 3];
+                    const mesh = new Mesh(gl, { geometry, program });
                     mesh.setParent(sphere);
                     mesh.rotation.y = (i * Math.PI) / 60;
                 }
@@ -126,7 +126,9 @@
                 requestAnimationFrame(update);
                 function update() {
                     requestAnimationFrame(update);
+
                     sphere.rotation.y -= 0.01;
+
                     controls.update();
                     renderer.render({ scene, camera });
                 }

--- a/examples/draw-modes.html
+++ b/examples/draw-modes.html
@@ -28,9 +28,9 @@
 
                 void main() {
                     vUv = uv;
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-                    
+
                     // gl_PointSize only applicable for gl.POINTS draw mode
                     gl_PointSize = 5.0;
                 }

--- a/examples/flat-shading-matcap.html
+++ b/examples/flat-shading-matcap.html
@@ -59,7 +59,7 @@
 
                     // We're using the matcap to add some shininess to the model
                     float mat = texture2D(tMap, matcap(normalize(vMVPos.xyz), normal)).g;
-                    
+
                     gl_FragColor.rgb = normal + mat;
                     gl_FragColor.a = 1.0;
                 }
@@ -122,7 +122,7 @@
                     uniforms: {
                         tMap: { value: texture },
                     },
-                    cullFace: null,
+                    cullFace: false,
                 });
 
                 loadModel();

--- a/examples/fog.html
+++ b/examples/fog.html
@@ -38,28 +38,28 @@
 
                 void main() {
                     vUv = uv;
-                    
+
                     // copy position so that we can modify the instances
                     vec3 pos = position;
-                    
+
                     // scale first
                     pos *= 0.8 + random.y * 0.3;
-                    
+
                     // pass scaled object position to fragment to add low-lying fog
                     vPos = pos;
-                    
+
                     // rotate around Y axis
                     rotate2d(pos.xz, random.x * 6.28);
-                    
+
                     // add position offset
                     pos += offset;
-                    
+
                     // add some hilliness to vary the height
                     pos.y += sin(pos.x * 0.5) * sin(pos.z * 0.5) * 0.5;
-                    
-                    // pass model view position to fragment shader to get distance from camera 
+
+                    // pass model view position to fragment shader to get distance from camera
                     vMVPos = modelViewMatrix * vec4(pos, 1.0);
-                    
+
                     gl_Position = projectionMatrix * vMVPos;
                 }
             `;
@@ -79,15 +79,15 @@
 
                 void main() {
                     vec3 tex = texture2D(tMap, vUv).rgb;
-                    
+
                     // add the fog relative to the distance from the camera
                     float dist = length(vMVPos);
                     float fog = smoothstep(uFogNear, uFogFar, dist);
                     tex = mix(tex, uFogColor, fog);
-                    
-                    // add some fog along the height of each tree to simulate low-lying fog 
-                    tex = mix(tex, uFogColor, smoothstep(1.0, 0.0, vPos.y)); 
-                    
+
+                    // add some fog along the height of each tree to simulate low-lying fog
+                    tex = mix(tex, uFogColor, smoothstep(1.0, 0.0, vPos.y));
+
                     gl_FragColor.rgb = tex;
                     gl_FragColor.a = 1.0;
                 }
@@ -167,6 +167,7 @@
                         mesh.rotation.y += 0.003;
                         mesh.position.z = Math.sin(t * 0.0004) * 3.0;
                     }
+
                     program.uniforms.uTime.value = t * 0.001;
                     renderer.render({ scene, camera });
                 }

--- a/examples/fresnel.html
+++ b/examples/fresnel.html
@@ -113,10 +113,10 @@
                 requestAnimationFrame(update);
                 function update() {
                     requestAnimationFrame(update);
+
                     torus.rotation.x += 0.01;
 
                     controls.update();
-
                     renderer.render({ scene, camera });
                 }
             }

--- a/examples/frustum-culling.html
+++ b/examples/frustum-culling.html
@@ -15,20 +15,7 @@
     <body>
         <div class="Info">Frustum Culling. Model by Google Poly</div>
         <script type="module">
-            import {
-                Renderer,
-                Camera,
-                Transform,
-                Texture,
-                Program,
-                Color,
-                Geometry,
-                Mesh,
-                Vec3,
-                Orbit,
-                Cylinder,
-                NormalProgram,
-            } from '../src/index.js';
+            import { Renderer, Camera, Transform, Texture, Program, Geometry, Mesh, Vec3, Orbit, Cylinder, NormalProgram } from '../src/index.js';
 
             const vertex = /* glsl */ `
                 attribute vec2 uv;
@@ -60,12 +47,12 @@
 
                 void main() {
                     vec3 tex = texture2D(tMap, vUv).rgb;
-                    
+
                     float dist = length(vMVPos);
                     float fog = smoothstep(2.0, 15.0, dist);
                     tex = mix(tex, vec3(1), fog * 0.8);
-                    tex = mix(tex, vec3(1), smoothstep(1.0, 0.0, vPos.y)); 
-                    
+                    tex = mix(tex, vec3(1), smoothstep(1.0, 0.0, vPos.y));
+
                     gl_FragColor.rgb = tex;
                     gl_FragColor.a = 1.0;
                 }
@@ -148,7 +135,7 @@
                         }),
                         program: new NormalProgram(gl),
                     });
-                    mesh.program.cullFace = null;
+                    mesh.program.cullFace = false;
 
                     mesh.setParent(frustumTransform);
                     mesh.isCameraShape = true;
@@ -167,8 +154,6 @@
                 requestAnimationFrame(update);
                 function update(t) {
                     requestAnimationFrame(update);
-
-                    controls.update();
 
                     // Move camera around a path
                     cameraPath(frustumCamera.position, t * 0.001, 2);
@@ -189,6 +174,7 @@
                         node.visible = frustumCamera.frustumIntersectsMesh(node);
                     });
 
+                    controls.update();
                     renderer.render({ scene, camera });
                 }
             }

--- a/examples/gltf-ktx2-basis.html
+++ b/examples/gltf-ktx2-basis.html
@@ -27,19 +27,8 @@
             // and then use it to compress the textures
             // gltf-transform etc1s scene.glb scene-compressed.glb
 
-            import {
-                Renderer,
-                Camera,
-                Transform,
-                Orbit,
-                Program,
-                BasisManager,
-                GLTFLoader,
-                GLTFSkin,
-                Vec3,
-                Color,
-                TextureLoader,
-            } from '../src/index.js';
+            import { Renderer, Camera, Transform, Orbit, Program, BasisManager, GLTFLoader, Vec3, TextureLoader } from '../src/index.js';
+
             const shader = {
                 vertex: /* glsl */ `
                     attribute vec3 position;
@@ -148,7 +137,7 @@
 
                         gl_Position = projectionMatrix * vMVPos;
                     }
-                    `,
+                `,
 
                 fragment: /* glsl */ `
                     uniform mat4 viewMatrix;
@@ -599,7 +588,7 @@
                             uAlphaCutoff: { value: gltf.alphaCutoff },
                         },
                         transparent: gltf.alphaMode === 'BLEND',
-                        cullFace: gltf.doubleSided ? null : gl.BACK,
+                        cullFace: gltf.doubleSided ? false : gl.BACK,
                     });
 
                     return program;
@@ -608,7 +597,6 @@
                 requestAnimationFrame(update);
                 function update() {
                     requestAnimationFrame(update);
-                    controls.update();
 
                     // Play first animation
                     if (gltf && gltf.animations && gltf.animations.length) {
@@ -617,6 +605,7 @@
                         animation.update();
                     }
 
+                    controls.update();
                     renderer.render({ scene, camera, sort: false, frustumCull: false });
                 }
             }

--- a/examples/gpgpu-particles.html
+++ b/examples/gpgpu-particles.html
@@ -15,7 +15,7 @@
     <body>
         <div class="Info">GPGPU Particles (General-Purpose computing on Graphics Processing Units)</div>
         <script type="module">
-            import { Renderer, Camera, Geometry, Program, Texture, Mesh, Vec2, GPGPU } from '../src/index.js';
+            import { Renderer, Camera, Geometry, Program, Mesh, Vec2, GPGPU } from '../src/index.js';
 
             const vertex = /* glsl */ `
                 attribute vec2 coords;
@@ -34,7 +34,7 @@
                     // Get position from texture, rather than attribute
                     vec4 position = texture2D(tPosition, coords);
                     vVelocity = texture2D(tVelocity, coords);
-                    
+
                     // Add some subtle random oscillating so it never fully stops
                     position.xy += sin(vec2(uTime) * vRandom.wy + vRandom.xz * 6.28) * vRandom.zy * 0.1;
 
@@ -43,7 +43,6 @@
 
                     // Make bigger while moving
                     gl_PointSize *= 1.0 + min(1.0, length(vVelocity.xy));
-
                 }
             `;
 
@@ -85,7 +84,7 @@
                     vec4 velocity = texture2D(tVelocity, vUv);
 
                     position.xy += velocity.xy * 0.01;
-                                    
+
                     // Keep in bounds
                     vec2 limits = vec2(1);
                     position.xy += (1.0 - step(-limits.xy, position.xy)) * limits.xy * 2.0;

--- a/examples/helpers.html
+++ b/examples/helpers.html
@@ -1,23 +1,36 @@
 <!DOCTYPE html>
 <html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+        <meta
+            name="viewport"
+            content="width=device-width, minimal-ui, viewport-fit=cover, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no"
+        />
+        <link rel="icon" type="image/png" href="assets/favicon.png" />
 
-<head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport"
-        content="width=device-width, minimal-ui, viewport-fit=cover, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
-    <link rel="icon" type="image/png" href="assets/favicon.png" />
+        <title>OGL • Helpers</title>
+        <link href="assets/main.css" rel="stylesheet" />
+    </head>
+    <body>
+        <div class="Info">Helpers</div>
+        <script type="module">
+            import {
+                Renderer,
+                Camera,
+                Transform,
+                Program,
+                Mesh,
+                Sphere,
+                Box,
+                Orbit,
+                AxesHelper,
+                VertexNormalsHelper,
+                FaceNormalsHelper,
+                GridHelper,
+            } from '../src/index.js';
 
-    <title>OGL • Helpers</title>
-    <link href="assets/main.css" rel="stylesheet" />
-</head>
-
-<body>
-    <div class="Info">Helpers</div>
-    <script type="module">
-        import { Renderer, Camera, Transform, Program, Mesh, Sphere, Box, Orbit, AxesHelper, VertexNormalsHelper, FaceNormalsHelper, GridHelper } from '../src/index.js';
-
-        const vertex = /* glsl */ `
+            const vertex = /* glsl */ `
                 attribute vec3 position;
                 attribute vec3 normal;
 
@@ -33,7 +46,7 @@
                 }
             `;
 
-        const fragment = /* glsl */ `
+            const fragment = /* glsl */ `
                 precision highp float;
 
                 varying vec3 vNormal;
@@ -46,70 +59,69 @@
                 }
             `;
 
-        {
-            const renderer = new Renderer({ dpr: 2 });
-            const gl = renderer.gl;
-            document.body.appendChild(gl.canvas);
-            gl.clearColor(1, 1, 1, 1);
+            {
+                const renderer = new Renderer({ dpr: 2 });
+                const gl = renderer.gl;
+                document.body.appendChild(gl.canvas);
+                gl.clearColor(1, 1, 1, 1);
 
-            const camera = new Camera(gl, { fov: 35 });
-            camera.position.set(1, 1, 7);
-            camera.lookAt([0, 0, 0]);
-            const controls = new Orbit(camera);
+                const camera = new Camera(gl, { fov: 35 });
+                camera.position.set(1, 1, 7);
+                camera.lookAt([0, 0, 0]);
+                const controls = new Orbit(camera);
 
-            function resize() {
-                renderer.setSize(window.innerWidth, window.innerHeight);
-                camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
-            }
-            window.addEventListener('resize', resize, false);
-            resize();
+                function resize() {
+                    renderer.setSize(window.innerWidth, window.innerHeight);
+                    camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
+                }
+                window.addEventListener('resize', resize, false);
+                resize();
 
-            const scene = new Transform();
+                const scene = new Transform();
 
-            const sphereGeometry = new Sphere(gl);
-            const cubeGeometry = new Box(gl);
+                const sphereGeometry = new Sphere(gl);
+                const cubeGeometry = new Box(gl);
 
-            const program = new Program(gl, { vertex, fragment });
+                const program = new Program(gl, { vertex, fragment });
 
-            const sphere = new Mesh(gl, { geometry: sphereGeometry, program });
-            sphere.position.set(-0.75, 0.5, 0);
-            sphere.setParent(scene);
+                const sphere = new Mesh(gl, { geometry: sphereGeometry, program });
+                sphere.position.set(-0.75, 0.5, 0);
+                sphere.setParent(scene);
 
-            const sphereVertNorms = new VertexNormalsHelper(sphere);
-            sphereVertNorms.setParent(scene);
+                const sphereVertNorms = new VertexNormalsHelper(sphere);
+                sphereVertNorms.setParent(scene);
 
-            const sphereFaceNorms = new FaceNormalsHelper(sphere);
-            sphereFaceNorms.setParent(scene);
+                const sphereFaceNorms = new FaceNormalsHelper(sphere);
+                sphereFaceNorms.setParent(scene);
 
-            const cube = new Mesh(gl, { geometry: cubeGeometry, program });
-            cube.position.set(0.75, 0.5, 0);
-            cube.setParent(scene);
+                const cube = new Mesh(gl, { geometry: cubeGeometry, program });
+                cube.position.set(0.75, 0.5, 0);
+                cube.setParent(scene);
 
-            const cubeVertNorms = new VertexNormalsHelper(cube);
-            cubeVertNorms.setParent(scene);
+                const cubeVertNorms = new VertexNormalsHelper(cube);
+                cubeVertNorms.setParent(scene);
 
-            const cubeFaceNorms = new FaceNormalsHelper(cube);
-            cubeFaceNorms.setParent(scene);
+                const cubeFaceNorms = new FaceNormalsHelper(cube);
+                cubeFaceNorms.setParent(scene);
 
-            const grid = new GridHelper(gl, { size: 10, divisions: 10 });
-            grid.position.y = -0.001; // shift down a little to avoid z-fighting with axes helper
-            grid.setParent(scene);
+                const grid = new GridHelper(gl, { size: 10, divisions: 10 });
+                grid.position.y = -0.001; // shift down a little to avoid z-fighting with axes helper
+                grid.setParent(scene);
 
-            const axes = new AxesHelper(gl, { size: 6, symmetric: true });
-            axes.setParent(scene);
+                const axes = new AxesHelper(gl, { size: 6, symmetric: true });
+                axes.setParent(scene);
 
-            requestAnimationFrame(update);
-            function update(now) {
-                controls.update();
-
-                sphere.scale.y = Math.cos(now * 0.001) * 2;
-                cube.rotation.y -= 0.01;
-
-                renderer.render({ scene, camera });
                 requestAnimationFrame(update);
-            }
-        }
-    </script>
-</body>
+                function update(t) {
+                    requestAnimationFrame(update);
 
+                    sphere.scale.y = Math.cos(t * 0.001) * 2;
+                    cube.rotation.y -= 0.01;
+
+                    controls.update();
+                    renderer.render({ scene, camera });
+                }
+            }
+        </script>
+    </body>
 </html>

--- a/examples/high-mesh-count.html
+++ b/examples/high-mesh-count.html
@@ -18,31 +18,30 @@
             <input id="meshCountInput" style="width: 100px"></input>
             <button  id="meshCountButton" style="padding:2px; border: 1px solid #000; background-color:#fff;" onclick="setMeshCount(document.getElementById('meshCountInput').value)">Set mesh count</button>
         </div>
-        
         <script type="module">
-            import {Renderer, Camera, Transform, Program, Mesh, Box} from '../src/index.js';
-            
+            import { Renderer, Camera, Transform, Program, Mesh, Box } from '../src/index.js';
+
             const vertex = /* glsl */ `
                 attribute vec3 position;
                 attribute vec3 normal;
-    
+
                 uniform mat4 modelViewMatrix;
                 uniform mat4 projectionMatrix;
                 uniform mat3 normalMatrix;
-    
+
                 varying vec3 vNormal;
-    
+
                 void main() {
                     vNormal = normalize(normalMatrix * normal);
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;
-    
+
             const fragment = /* glsl */ `
                 precision highp float;
-    
+
                 varying vec3 vNormal;
-    
+
                 void main() {
                     vec3 normal = normalize(vNormal);
                     float lighting = dot(normal, normalize(vec3(-0.3, 0.8, 0.6)));
@@ -50,49 +49,48 @@
                     gl_FragColor.a = 1.0;
                 }
             `;
-    
+
             {
                 const renderer = new Renderer();
                 const gl = renderer.gl;
                 document.body.appendChild(gl.canvas);
                 gl.clearColor(1, 1, 1, 1);
-    
-                const camera = new Camera(gl, {fov: 35, far: 3000});
-    
+
+                const camera = new Camera(gl, { fov: 35, far: 3000 });
+
                 function resize() {
                     renderer.setSize(window.innerWidth, window.innerHeight);
-                    camera.perspective({aspect: gl.canvas.width / gl.canvas.height});
+                    camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
                 }
                 window.addEventListener('resize', resize, false);
                 resize();
-    
+
                 const scene = new Transform();
-    
+
                 // Create base geometry
                 const cubeGeometry = new Box(gl);
-    
+
                 // Using the shader from the base primitive example
                 const program = new Program(gl, {
                     vertex,
                     fragment,
                 });
-    
+
                 // mesh container
                 let meshes = [];
-    
+
                 window.setMeshCount = function setMeshCount(count) {
-    
                     // sanitize input
                     count = parseInt(count) || 1000;
-    
+
                     // remove old meshes
-                    for(let i = 0; i < meshes.length; ++i) scene.removeChild(meshes[i]);
+                    for (let i = 0; i < meshes.length; ++i) scene.removeChild(meshes[i]);
                     meshes = [];
-    
+
                     // create our meshes according to input
-                    for (let i = 0; i < count; ++i){
-                        let mesh = new Mesh(gl, {geometry: cubeGeometry, program});
-    
+                    for (let i = 0; i < count; ++i) {
+                        let mesh = new Mesh(gl, { geometry: cubeGeometry, program });
+
                         // position meshes in a random position between -100 / +100 in each dimension
                         mesh.position.set(
                             -100 + Math.random() * 200,
@@ -101,32 +99,31 @@
                         );
                         mesh.rotation.set(Math.random() * 3, Math.random() * 3, Math.random() * 3);
                         scene.addChild(mesh);
-                        meshes.push(mesh)
+                        meshes.push(mesh);
                     }
-    
+
                     // set input counter value to make sure
                     document.getElementById('meshCountInput').value = count;
-    
-                }
-    
+                };
+
                 setMeshCount(1000);
-    
+
                 requestAnimationFrame(update);
                 function update() {
                     requestAnimationFrame(update);
-    
+
                     // rotate camera
                     let time = performance.now() / 30000;
                     camera.position.set(Math.sin(time) * 180, 80, Math.cos(time) * 180);
                     camera.lookAt([0, 0, 0]);
-    
+
                     // rotate meshes
-                    for(let i = 0; i < meshes.length; ++i){
-                        meshes[i].rotation.x += 0.01
-                        meshes[i].rotation.y += 0.01
+                    for (let i = 0; i < meshes.length; ++i) {
+                        meshes[i].rotation.x += 0.01;
+                        meshes[i].rotation.y += 0.01;
                     }
-    
-                    renderer.render({scene, camera});
+
+                    renderer.render({ scene, camera });
                 }
             }
         </script>

--- a/examples/indexed-vs-non-indexed.html
+++ b/examples/indexed-vs-non-indexed.html
@@ -28,7 +28,7 @@
 
                 void main() {
                     vUv = uv;
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;

--- a/examples/instancing-gpu-picking.html
+++ b/examples/instancing-gpu-picking.html
@@ -15,7 +15,7 @@
     <body>
         <div class="Info">Instancing with GPU Picking. Model by Google Poly</div>
         <script type="module">
-            import { Renderer, Camera, RenderTarget, Vec3, Transform, Texture, Program, Box, Mesh, NormalProgram } from '../src/index.js';
+            import { Renderer, Camera, RenderTarget, Vec3, Transform, Program, Box, Mesh, NormalProgram } from '../src/index.js';
 
             const vertex = /* glsl */ `
                 attribute vec2 uv;
@@ -44,18 +44,18 @@
                     vUv = uv;
                     vId = id;
                     vNormal = normal;
-                    
+
                     // copy position so that we can modify the instances
                     vec3 pos = position;
-                    
+
                     // scale first
                     pos *= 0.9 + random.y * 0.2;
-                    
+
                     // rotate around y axis
                     rotate2d(pos.xz, random.x * 6.28 + 4.0 * uTime * (random.y - 0.5));
-                    
+
                     pos += offset;
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
                 }
             `;
@@ -156,7 +156,7 @@
                     mesh.setParent(scene);
 
                     // Create a single non-instanced copy
-                    highlight = new Mesh(gl, { geometry, program: NormalProgram(gl) });
+                    highlight = new Mesh(gl, { geometry, program: new NormalProgram(gl) });
                     highlight.setParent(scene);
                     highlight.visible = false;
                 }
@@ -182,6 +182,7 @@
                 requestAnimationFrame(update);
                 function update(t) {
                     requestAnimationFrame(update);
+
                     if (!mesh) return;
 
                     let time = t * 0.001;

--- a/examples/instancing.html
+++ b/examples/instancing.html
@@ -39,21 +39,21 @@
 
                 void main() {
                     vUv = uv;
-                    
+
                     // copy position so that we can modify the instances
                     vec3 pos = position;
-                    
+
                     // scale first
                     pos *= 0.9 + random.y * 0.2;
-                    
+
                     // rotate around y axis
                     rotate2d(pos.xz, random.x * 6.28 + 4.0 * uTime * (random.y - 0.5));
-                    
+
                     // rotate around x axis just to add some extra variation
                     rotate2d(pos.zy, random.z * 0.5 * sin(uTime * random.x + random.z * 3.14));
-                    
+
                     pos += offset;
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
                 }
             `;
@@ -68,7 +68,7 @@
 
                 void main() {
                     vec3 tex = texture2D(tMap, vUv).rgb;
-                    
+
                     gl_FragColor.rgb = tex;
                     gl_FragColor.a = 1.0;
                 }

--- a/examples/load-gltf.html
+++ b/examples/load-gltf.html
@@ -18,7 +18,8 @@
             <a href="https://sketchfab.com/3d-models/hershel-little-america-f4d7a0ed8af2453e9adc632278c9aa50" target="_blank">VRModelFactory</a>
         </div>
         <script type="module">
-            import { Renderer, Camera, Transform, Orbit, Program, GLTFLoader, GLTFSkin, Vec3, Color, TextureLoader } from '../src/index.js';
+            import { Renderer, Camera, Transform, Orbit, Program, GLTFLoader, Vec3, TextureLoader } from '../src/index.js';
+
             const shader = {
                 vertex: /* glsl */ `
                     attribute vec3 position;
@@ -127,7 +128,7 @@
 
                         gl_Position = projectionMatrix * vMVPos;
                     }
-                    `,
+                `,
 
                 fragment: /* glsl */ `
                     uniform mat4 viewMatrix;
@@ -187,7 +188,7 @@
                     }
 
                     vec3 getNormal() ${`{`}
-                        #ifdef NORMAL_MAP  
+                        #ifdef NORMAL_MAP
                             vec3 pos_dx = dFdx(vMPos.xyz);
                             vec3 pos_dy = dFdy(vMPos.xyz);
                             vec2 tex_dx = dFdx(vUv);
@@ -246,7 +247,7 @@
                         float level0 = floor(blend);
                         float level1 = min(ENV_LODS, level0 + 1.0);
                         blend -= level0;
-                        
+
                         // Sample the specular env map atlas depending on the roughness value
                         vec2 uvSpec = cartesianToPolar(reflection);
                         uvSpec.y /= 2.0;
@@ -265,7 +266,7 @@
                         vec3 specularLight = mix(specular0, specular1, blend);
 
                         diffuse = diffuseLight * diffuseColor;
-                        
+
                         // Bit of extra reflection for smooth materials
                         float reflectivity = pow((1.0 - roughness), 2.0) * 0.05;
                         specular = specularLight * (specularColor * brdf.x + brdf.y + reflectivity);
@@ -318,7 +319,7 @@
 
                         vec3 diffuseContrib = (1.0 - F) * (diffuseColor / PI);
                         vec3 specContrib = F * G * D / (4.0 * NdL * NdV);
-                        
+
                         // Shading based off lights
                         vec3 color = NdL * uLightColor * (diffuseContrib + specContrib);
 
@@ -336,19 +337,19 @@
                         // Add IBL spec to alpha for reflections on transparent surfaces (glass)
                         alpha = max(alpha, max(max(specularIBL.r, specularIBL.g), specularIBL.b));
 
-                        #ifdef OCC_MAP  
+                        #ifdef OCC_MAP
                             // TODO: figure out how to apply occlusion
                             // color *= SRGBtoLinear(texture2D(tOcclusion, vUv)).rgb;
                         #endif
 
-                        #ifdef EMISSIVE_MAP  
+                        #ifdef EMISSIVE_MAP
                             vec3 emissive = SRGBtoLinear(texture2D(tEmissive, vUv)).rgb * uEmissive;
                             color += emissive;
                         #endif
 
                         // Convert to sRGB to display
                         gl_FragColor.rgb = linearToSRGB(color);
-                        
+
                         // Apply uAlpha uniform at the end to overwrite any specular additions on transparent surfaces
                         gl_FragColor.a = alpha * uAlpha;
                     }
@@ -574,7 +575,7 @@
                             uAlphaCutoff: { value: gltf.alphaCutoff },
                         },
                         transparent: gltf.alphaMode === 'BLEND',
-                        cullFace: gltf.doubleSided ? null : gl.BACK,
+                        cullFace: gltf.doubleSided ? false : gl.BACK,
                     });
 
                     return program;
@@ -583,7 +584,6 @@
                 requestAnimationFrame(update);
                 function update() {
                     requestAnimationFrame(update);
-                    controls.update();
 
                     // Play first animation
                     if (gltf && gltf.animations && gltf.animations.length) {
@@ -592,6 +592,7 @@
                         animation.update();
                     }
 
+                    controls.update();
                     renderer.render({ scene, camera, sort: false, frustumCull: false });
                 }
             }

--- a/examples/load-json.html
+++ b/examples/load-json.html
@@ -32,7 +32,7 @@
                 void main() {
                     vUv = uv;
                     vNormal = normalize(normalMatrix * normal);
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;
@@ -49,7 +49,7 @@
                 void main() {
                     vec3 normal = normalize(vNormal);
                     vec3 tex = texture2D(tMap, vUv).rgb;
-                    
+
                     vec3 light = normalize(vec3(0.5, 1.0, -0.3));
                     float shading = dot(normal, light) * 0.15;
                     gl_FragColor.rgb = tex + shading;

--- a/examples/mouse-flowmap.html
+++ b/examples/mouse-flowmap.html
@@ -42,7 +42,7 @@
                 varying vec2 vUv;
 
                 void main() {
-                    
+
                     // R and G values are velocity in the x and y direction
                     // B value is the velocity length
                     vec3 flow = texture2D(tFlow, vUv).rgb;

--- a/examples/mrt.html
+++ b/examples/mrt.html
@@ -15,20 +15,7 @@
     <body>
         <div class="Info" style="color: #fff">MRT (Multiple Render Targets)</div>
         <script type="module">
-            import {
-                Renderer,
-                Camera,
-                Transform,
-                Geometry,
-                Texture,
-                RenderTarget,
-                Program,
-                Mesh,
-                Vec3,
-                Vec2,
-                Orbit,
-                Triangle,
-            } from '../src/index.js';
+            import { Renderer, Camera, Transform, Geometry, Texture, RenderTarget, Program, Mesh, Vec3, Orbit, Triangle } from '../src/index.js';
 
             const vertex100 = /* glsl */ `
                 attribute vec3 position;
@@ -61,13 +48,13 @@
                     vUv = uv;
                     vNormal = normalize(normalMatrix * normal);
                     vMPos = (modelMatrix * vec4(pos, 1.0)).xyz;
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
                 }
             `;
 
             const fragment100 = /* glsl */ `
-                #extension GL_EXT_draw_buffers : require 
+                #extension GL_EXT_draw_buffers : require
 
                 precision highp float;
 
@@ -78,7 +65,7 @@
                 varying vec3 vMPos;
 
                 void main() {
-                    gl_FragData[0] = texture2D(tMap, vUv); 
+                    gl_FragData[0] = texture2D(tMap, vUv);
                     gl_FragData[1] = vec4(vMPos, gl_FragCoord.z);
                 }
             `;
@@ -114,7 +101,7 @@
                     vUv = uv;
                     vNormal = normalize(normalMatrix * normal);
                     vMPos = (modelMatrix * vec4(pos, 1.0)).xyz;
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
                 }
             `;
@@ -131,7 +118,7 @@
                 out vec4 FragData[2];
 
                 void main() {
-                    FragData[0] = texture(tMap, vUv); 
+                    FragData[0] = texture(tMap, vUv);
                     FragData[1] = vec4(vMPos, gl_FragCoord.z);
                 }
             `;
@@ -195,7 +182,6 @@
                     } else if (uv.y < 3.0 && uv.x < 1.0) {
                         gl_FragColor.rgb = texture2D(tColor, mod(uv, 1.0)).rgb;
                     }
-
                 }
             `;
 
@@ -301,6 +287,7 @@
                 requestAnimationFrame(update);
                 function update(t) {
                     requestAnimationFrame(update);
+
                     controls.update();
 
                     // Render scene to targets

--- a/examples/msdf-text.html
+++ b/examples/msdf-text.html
@@ -28,7 +28,7 @@
 
                 void main() {
                     vUv = uv;
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;
@@ -96,19 +96,19 @@
                 const scene = new Transform();
 
                 /*
-            
-            Instructions to generate necessary MSDF assets
 
-            Install msdf-bmfont https://github.com/soimy/msdf-bmfont-xml
-            `npm install msdf-bmfont-xml -g`
+                Instructions to generate necessary MSDF assets
 
-            Then, using a font .ttf file, run the following (using 'FiraSans-Bold.ttf' as example)
+                Install msdf-bmfont https://github.com/soimy/msdf-bmfont-xml
+                `npm install msdf-bmfont-xml -g`
 
-            `msdf-bmfont -f json -m 512,512 -d 2 --pot --smart-size FiraSans-Bold.ttf`
+                Then, using a font .ttf file, run the following (using 'FiraSans-Bold.ttf' as example)
 
-            Outputs a .png bitmap spritesheet and a .json with character parameters.
+                `msdf-bmfont -f json -m 512,512 -d 2 --pot --smart-size FiraSans-Bold.ttf`
 
-            */
+                Outputs a .png bitmap spritesheet and a .json with character parameters.
+
+                */
 
                 const texture = new Texture(gl, {
                     generateMipmaps: false,
@@ -125,7 +125,7 @@
                         tMap: { value: texture },
                     },
                     transparent: true,
-                    cullFace: null,
+                    cullFace: false,
                     depthWrite: false,
                 });
 
@@ -162,6 +162,7 @@
                 requestAnimationFrame(update);
                 function update(t) {
                     requestAnimationFrame(update);
+
                     controls.update();
                     renderer.render({ scene, camera });
                 }

--- a/examples/normal-maps.html
+++ b/examples/normal-maps.html
@@ -79,10 +79,10 @@
                     vec3 tex = texture2D(tDiffuse, vUv).rgb;
 
                     vec3 normal = getNormal();
-                    
+
                     vec3 light = normalize(vec3(sin(uTime), 1.0, cos(uTime)));
                     float shading = dot(normal, light) * 0.5;
-                    
+
                     gl_FragColor.rgb = tex + shading;
                     gl_FragColor.a = 1.0;
                 }
@@ -150,10 +150,10 @@
                     vec3 tex = texture(tDiffuse, vUv).rgb;
 
                     vec3 normal = getNormal();
-                    
+
                     vec3 light = normalize(vec3(sin(uTime), 1.0, cos(uTime)));
                     float shading = dot(normal, light) * 0.5;
-                    
+
                     FragColor.rgb = tex + shading;
                     FragColor.a = 1.0;
                 }
@@ -219,9 +219,10 @@
                 requestAnimationFrame(update);
                 function update(t) {
                     requestAnimationFrame(update);
-                    controls.update();
 
                     program.uniforms.uTime.value = t * 0.001;
+
+                    controls.update();
                     renderer.render({ scene, camera });
                 }
             }

--- a/examples/orbit-controls.html
+++ b/examples/orbit-controls.html
@@ -42,7 +42,7 @@
                 void main() {
                     vUv = uv;
                     vNormal = normalize(normalMatrix * normal);
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;
@@ -59,7 +59,7 @@
                 void main() {
                     vec3 normal = normalize(vNormal);
                     vec3 tex = texture2D(tMap, vUv).rgb;
-                    
+
                     vec3 light = normalize(vec3(0.5, 1.0, -0.3));
                     float shading = dot(normal, light) * 0.15;
                     gl_FragColor.rgb = tex + shading;
@@ -105,7 +105,7 @@
                     uniforms: {
                         tMap: { value: texture },
                     },
-                    cullFace: null,
+                    cullFace: false,
                 });
 
                 let mesh;
@@ -119,7 +119,7 @@
                         normal: { size: 3, data: new Float32Array(data.normal) },
                     });
 
-                    let mesh = new Mesh(gl, { geometry, program });
+                    mesh = new Mesh(gl, { geometry, program });
                     mesh.setParent(scene);
                 }
 

--- a/examples/particles.html
+++ b/examples/particles.html
@@ -30,13 +30,13 @@
 
                 void main() {
                     vRandom = random;
-                    
+
                     // positions are 0->1, so make -1->1
                     vec3 pos = position * 2.0 - 1.0;
-                    
+
                     // Scale towards camera to be more interesting
                     pos.z *= 10.0;
-                    
+
                     // modelMatrix is one of the automatically attached uniforms when using the Mesh class
                     vec4 mPos = modelMatrix * vec4(pos, 1.0);
 
@@ -45,7 +45,7 @@
                     mPos.x += sin(t * random.z + 6.28 * random.w) * mix(0.1, 1.5, random.x);
                     mPos.y += sin(t * random.y + 6.28 * random.x) * mix(0.1, 1.5, random.w);
                     mPos.z += sin(t * random.w + 6.28 * random.y) * mix(0.1, 1.5, random.z);
-                    
+
                     // get the model view position so that we can scale the points off into the distance
                     vec4 mvPos = viewMatrix * mPos;
                     gl_PointSize = 300.0 / length(mvPos.xyz) * (random.x + 0.1);
@@ -62,9 +62,9 @@
 
                 void main() {
                     vec2 uv = gl_PointCoord.xy;
-                    
+
                     float circle = smoothstep(0.5, 0.4, length(uv - 0.5)) * 0.8;
-                    
+
                     gl_FragColor.rgb = 0.8 + 0.2 * sin(uv.yxx + uTime + vRandom.y * 6.28) + vec3(0.1, 0.0, 0.3);
                     gl_FragColor.a = circle;
                 }

--- a/examples/paths.html
+++ b/examples/paths.html
@@ -1,173 +1,195 @@
 <!DOCTYPE html>
 <html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+        <meta
+            name="viewport"
+            content="width=device-width, minimal-ui, viewport-fit=cover, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no"
+        />
+        <link rel="icon" type="image/png" href="assets/favicon.png" />
 
-<head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport"
-        content="width=device-width, minimal-ui, viewport-fit=cover, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
-    <link rel="icon" type="image/png" href="assets/favicon.png" />
+        <title>OGL • Paths</title>
+        <link href="assets/main.css" rel="stylesheet" />
+    </head>
+    <body>
+        <div class="Info">Paths</div>
+        <script type="module">
+            import { Renderer, Camera, Transform, Program, Mesh, Sphere, Polyline, Vec3, Color, Path } from '../src/index.js';
 
-    <title>OGL • Paths</title>
-    <link href="assets/main.css" rel="stylesheet" />
-</head>
+            const vertex = /* glsl */ `
+                attribute vec3 position;
+                attribute vec3 normal;
 
-<body>
-    <div class="Info">Paths</div>
-    <script type="module">
-        import { Renderer, Camera, Transform, Program, Mesh, Sphere, Polyline, Vec3, Color, Path } from '../src/index.js';
+                uniform mat4 modelViewMatrix;
+                uniform mat4 projectionMatrix;
+                uniform mat3 normalMatrix;
 
-        const vertex = /* glsl */ `
-            attribute vec3 position;
-            attribute vec3 normal;
+                varying vec3 vNormal;
 
-            uniform mat4 modelViewMatrix;
-            uniform mat4 projectionMatrix;
-            uniform mat3 normalMatrix;
+                void main() {
+                    vNormal = normalize(normalMatrix * normal);
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `;
 
-            varying vec3 vNormal;
+            const fragmentColor1 = /* glsl */ `
+                precision highp float;
+                varying vec3 vNormal;
 
-            void main() {
-                vNormal = normalize(normalMatrix * normal);
-                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-            }`;
+                void main() {
+                    vec3 normal = normalize(vNormal);
+                    float lighting = dot(normal, normalize(vec3(-0.3, 0.8, 0.6)));
+                    gl_FragColor.rgb = vec3(0.24, 0.84, 1.0) + lighting * 0.1;
+                    gl_FragColor.a = 1.0;
+                }
+            `;
 
-        const fragmentColor1 = /* glsl */ `
-            precision highp float;
-            varying vec3 vNormal;
+            const fragmentColor2 = /* glsl */ `
+                precision highp float;
+                varying vec3 vNormal;
 
-            void main() {
-                vec3 normal = normalize(vNormal);
-                float lighting = dot(normal, normalize(vec3(-0.3, 0.8, 0.6)));
-                gl_FragColor.rgb = vec3(0.24, 0.84, 1.0) + lighting * 0.1;
-                gl_FragColor.a = 1.0;
-            }`;
+                void main() {
+                    vec3 normal = normalize(vNormal);
+                    float lighting = dot(normal, normalize(vec3(-0.3, 0.8, 0.6)));
+                    gl_FragColor.rgb = vec3(0.93, 0.25, 0.41) + lighting * 0.1;
+                    gl_FragColor.a = 1.0;
+                }
+            `;
 
-        const fragmentColor2 = /* glsl */ `
-            precision highp float;
-            varying vec3 vNormal;
+            {
+                const renderer = new Renderer({ dpr: 2 });
+                const gl = renderer.gl;
+                document.body.appendChild(gl.canvas);
+                gl.clearColor(1, 1, 1, 1);
 
-            void main() {
-                vec3 normal = normalize(vNormal);
-                float lighting = dot(normal, normalize(vec3(-0.3, 0.8, 0.6)));
-                gl_FragColor.rgb = vec3(0.93, 0.25, 0.41) + lighting * 0.1;
-                gl_FragColor.a = 1.0;
-            }`;
+                const camera = new Camera(gl, { fov: 35 });
 
-        {
-            const renderer = new Renderer({ dpr: 2 });
-            const gl = renderer.gl;
-            document.body.appendChild(gl.canvas);
-            gl.clearColor(1, 1, 1, 1);
+                function resize() {
+                    renderer.setSize(window.innerWidth, window.innerHeight);
+                    camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
+                }
+                window.addEventListener('resize', resize, false);
+                resize();
 
-            const camera = new Camera(gl, { fov: 35 });
+                const scene = new Transform();
 
-            function resize() {
-                renderer.setSize(window.innerWidth, window.innerHeight);
-                camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
-            }
-            window.addEventListener('resize', resize, false);
-            resize();
+                const sphereGeom = new Sphere(gl);
+                const sphereProg1 = new Program(gl, { vertex, fragment: fragmentColor1 });
+                const sphereProg2 = new Program(gl, { vertex, fragment: fragmentColor2 });
 
-            const scene = new Transform();
+                // First three is for moveTo command, rest for bezierCurveTo command
+                const pathCoords = [
+                    -1.0, 0.0, 0.0, -0.9368709325790405, 0.1762027144432068, 0.04529910162091255, -0.7061498761177063, 0.089231938123703,
+                    0.19381383061408997, -0.6332840919494629, 0.2674865424633026, 0.1930660903453827, -0.5615311861038208, 0.4430185854434967,
+                    0.1923297792673111, -0.7734173536300659, 0.5522762537002563, 0.08718681335449219, -0.7070468664169312, 0.7070468664169312, 0.0,
+                    -0.6498651504516602, 0.8403899073600769, -0.07511603832244873, -0.5399253368377686, 0.8584117889404297, -0.16668838262557983,
+                    -0.38917776942253113, 0.921392560005188, -0.1677459478378296, -0.23391252756118774, 0.9862607717514038, -0.16883520781993866,
+                    -0.14611071348190308, 1.0727460384368896, -0.04093937203288078, 0.0, 1.0, 0.0, 0.1674281358718872, 0.9166403412818909,
+                    0.046912387013435364, 0.07777689397335052, 0.6478093862533569, -0.06732462346553802, 0.2400655597448349, 0.5683639645576477, 0.0,
+                    0.4298238456249237, 0.4754713177680969, 0.07872024923563004, 0.49316900968551636, 0.7766210436820984, 0.32597726583480835,
+                    0.7070468664169312, 0.7070468664169312, 0.3101717531681061, 0.8896822333335876, 0.647635817527771, 0.29667505621910095,
+                    0.8556811809539795, 0.5579423308372498, 0.06533028930425644, 0.921392560005188, 0.38917776942253113, 0.0, 0.9742976427078247,
+                    0.2533031702041626, -0.05259828269481659, 1.0508142709732056, 0.14183028042316437, -0.036462459713220596, 1.0, 0.0, 0.0,
+                    0.9368709325790405, -0.1762027144432068, 0.04529910162091255, 0.7061498761177063, -0.089231938123703, 0.19381383061408997,
+                    0.6332840919494629, -0.2674865424633026, 0.1930660903453827, 0.5615311861038208, -0.4430185854434967, 0.1923297792673111,
+                    0.7734173536300659, -0.5522762537002563, 0.08718681335449219, 0.7070468664169312, -0.7070468664169312, 0.0, 0.6498651504516602,
+                    -0.8403899073600769, -0.07511603832244873, 0.5399253368377686, -0.8584117889404297, -0.16668838262557983, 0.38917776942253113,
+                    -0.921392560005188, -0.1677459478378296, 0.23391252756118774, -0.9862607717514038, -0.16883520781993866, 0.14611071348190308,
+                    -1.0727460384368896, -0.04093937203288078, 0.0, -1.0, 0.0, -0.1674281358718872, -0.9166403412818909, 0.046912387013435364,
+                    -0.07777689397335052, -0.6478093862533569, -0.06732462346553802, -0.2400655597448349, -0.5683639645576477, 0.0,
+                    -0.4298238456249237, -0.4754713177680969, 0.07872024923563004, -0.49316900968551636, -0.7766210436820984, 0.32597726583480835,
+                    -0.7070468664169312, -0.7070468664169312, 0.3101717531681061, -0.8896822333335876, -0.647635817527771, 0.29667505621910095,
+                    -0.8556811809539795, -0.5579423308372498, 0.06533028930425644, -0.921392560005188, -0.38917776942253113, 0.0, -0.9742976427078247,
+                    -0.2533031702041626, -0.05259828269481659, -1.0508142709732056, -0.14183028042316437, -0.036462459713220596, -1.0, 0.0, 0.0,
+                ];
 
-            const sphereGeom = new Sphere(gl);
-            const sphereProg1 = new Program(gl, { vertex, fragment: fragmentColor1 });
-            const sphereProg2 = new Program(gl, { vertex, fragment: fragmentColor2 });
+                // Constructing path from cubic Bezier segments.
+                // Also available `quadraticCurveTo` and `lineTo` commands
+                const path = new Path();
+                path.moveTo(new Vec3(pathCoords[0], pathCoords[1], pathCoords[2]));
+                for (let i = 3; i < pathCoords.length; i += 9) {
+                    const cp1 = new Vec3(pathCoords[i + 0], pathCoords[i + 1], pathCoords[i + 2]);
+                    const cp2 = new Vec3(pathCoords[i + 3], pathCoords[i + 4], pathCoords[i + 5]);
+                    const p = new Vec3(pathCoords[i + 6], pathCoords[i + 7], pathCoords[i + 8]);
+                    path.bezierCurveTo(cp1, cp2, p);
+                }
 
-            // First three is for moveTo command, rest for bezierCurveTo command
-            const pathCoords = [-1.0, 0.0, 0.0, -0.9368709325790405, 0.1762027144432068, 0.04529910162091255, -0.7061498761177063, 0.089231938123703, 0.19381383061408997, -0.6332840919494629, 0.2674865424633026, 0.1930660903453827, -0.5615311861038208, 0.4430185854434967, 0.1923297792673111, -0.7734173536300659, 0.5522762537002563, 0.08718681335449219, -0.7070468664169312, 0.7070468664169312, 0.0, -0.6498651504516602, 0.8403899073600769, -0.07511603832244873, -0.5399253368377686, 0.8584117889404297, -0.16668838262557983, -0.38917776942253113, 0.921392560005188, -0.1677459478378296, -0.23391252756118774, 0.9862607717514038, -0.16883520781993866, -0.14611071348190308, 1.0727460384368896, -0.04093937203288078, 0.0, 1.0, 0.0, 0.1674281358718872, 0.9166403412818909, 0.046912387013435364, 0.07777689397335052, 0.6478093862533569, -0.06732462346553802, 0.2400655597448349, 0.5683639645576477, 0.0, 0.4298238456249237, 0.4754713177680969, 0.07872024923563004, 0.49316900968551636, 0.7766210436820984, 0.32597726583480835, 0.7070468664169312, 0.7070468664169312, 0.3101717531681061, 0.8896822333335876, 0.647635817527771, 0.29667505621910095, 0.8556811809539795, 0.5579423308372498, 0.06533028930425644, 0.921392560005188, 0.38917776942253113, 0.0, 0.9742976427078247, 0.2533031702041626, -0.05259828269481659, 1.0508142709732056, 0.14183028042316437, -0.036462459713220596, 1.0, 0.0, 0.0, 0.9368709325790405, -0.1762027144432068, 0.04529910162091255, 0.7061498761177063, -0.089231938123703, 0.19381383061408997, 0.6332840919494629, -0.2674865424633026, 0.1930660903453827, 0.5615311861038208, -0.4430185854434967, 0.1923297792673111, 0.7734173536300659, -0.5522762537002563, 0.08718681335449219, 0.7070468664169312, -0.7070468664169312, 0.0, 0.6498651504516602, -0.8403899073600769, -0.07511603832244873, 0.5399253368377686, -0.8584117889404297, -0.16668838262557983, 0.38917776942253113, -0.921392560005188, -0.1677459478378296, 0.23391252756118774, -0.9862607717514038, -0.16883520781993866, 0.14611071348190308, -1.0727460384368896, -0.04093937203288078, 0.0, -1.0, 0.0, -0.1674281358718872, -0.9166403412818909, 0.046912387013435364, -0.07777689397335052, -0.6478093862533569, -0.06732462346553802, -0.2400655597448349, -0.5683639645576477, 0.0, -0.4298238456249237, -0.4754713177680969, 0.07872024923563004, -0.49316900968551636, -0.7766210436820984, 0.32597726583480835, -0.7070468664169312, -0.7070468664169312, 0.3101717531681061, -0.8896822333335876, -0.647635817527771, 0.29667505621910095, -0.8556811809539795, -0.5579423308372498, 0.06533028930425644, -0.921392560005188, -0.38917776942253113, 0.0, -0.9742976427078247, -0.2533031702041626, -0.05259828269481659, -1.0508142709732056, -0.14183028042316437, -0.036462459713220596, -1.0, 0.0, 0.0];
+                // Tilt function receive an angle, relative path length offset in range [0..1] and path object instance.
+                // Should return new tilt angle
+                path.tiltFunction = (angle, t, path) => 8 * 360 * t;
 
-            // Constructing path from cubic Bezier segments.
-            // Also available `quadraticCurveTo` and `lineTo` commands
-            const path = new Path();
-            path.moveTo(new Vec3(pathCoords[0], pathCoords[1], pathCoords[2]));
-            for (let i = 3; i < pathCoords.length; i += 9) {
-                const cp1 = new Vec3(pathCoords[i + 0], pathCoords[i + 1], pathCoords[i + 2]);
-                const cp2 = new Vec3(pathCoords[i + 3], pathCoords[i + 4], pathCoords[i + 5]);
-                const p = new Vec3(pathCoords[i + 6], pathCoords[i + 7], pathCoords[i + 8]);
-                path.bezierCurveTo(cp1, cp2, p);
-            }
+                const pathSubdivisions = 256;
+                const points = path.getPoints(pathSubdivisions);
 
-            // Tilt function receive an angle, relative path length offset in range [0..1] and path object instance.
-            // Should return new tilt angle
-            path.tiltFunction = (angle, t, path) => 8 * 360 * t;
+                // create polyline from points
+                // see example: https://oframe.github.io/ogl/examples/?src=polylines.html
+                const polyline = new Polyline(gl, {
+                    points,
+                    uniforms: {
+                        uColor: { value: new Color('#ddd') },
+                        uThickness: { value: 3 },
+                    },
+                });
 
-            const pathSubdivisions = 256;
-            const points = path.getPoints(pathSubdivisions);
+                const mesh = new Mesh(gl, { geometry: polyline.geometry, program: polyline.program });
+                mesh.setParent(scene);
 
-            // create polyline from points
-            // see example: https://oframe.github.io/ogl/examples/?src=polylines.html
-            const polyline = new Polyline(gl, {
-                points,
-                uniforms: {
-                    uColor: { value: new Color('#ddd') },
-                    uThickness: { value: 3 },
-                },
-            });
+                // Generates the Frenet Frames.
+                // See http://www.cs.indiana.edu/pub/techreports/TR425.pdf
+                const frenetFrames = path.computeFrenetFrames(pathSubdivisions, true);
+                // if the path is closed,                                       ^
+                // then the paths ends will be aligned with each other ----------
 
-            const mesh = new Mesh(gl, { geometry: polyline.geometry, program: polyline.program });
-            mesh.setParent(scene);
+                for (let i = 0; i < points.length - 1; i++) {
+                    const point = points[i];
+                    const tangent = frenetFrames.tangents[i];
+                    const normal = frenetFrames.normals[i];
+                    const binormal = frenetFrames.binormals[i];
 
-            // Generates the Frenet Frames.
-            // See http://www.cs.indiana.edu/pub/techreports/TR425.pdf
-            const frenetFrames = path.computeFrenetFrames(pathSubdivisions, true);
-            // if the path is closed,                                       ^
-            // then the paths ends will be aligned with each other ----------
+                    const leftSphere = new Mesh(gl, { geometry: sphereGeom, program: sphereProg1 });
+                    leftSphere.scale.set(0.04);
+                    leftSphere.position.add(point, binormal.clone().scale(0.12));
+                    leftSphere.setParent(scene);
 
-            for (let i = 0; i < points.length - 1; i++) {
-                const point = points[i];
-                const tangent = frenetFrames.tangents[i];
-                const normal = frenetFrames.normals[i];
-                const binormal = frenetFrames.binormals[i];
+                    const rightSphere = new Mesh(gl, { geometry: sphereGeom, program: sphereProg2 });
+                    rightSphere.scale.set(0.04);
+                    rightSphere.position.add(point, binormal.clone().scale(-0.12));
+                    rightSphere.setParent(scene);
+                }
 
-                const leftSphere = new Mesh(gl, { geometry: sphereGeom, program: sphereProg1 });
-                leftSphere.scale.set(0.04);
-                leftSphere.position.add(point, binormal.clone().scale(0.12));
-                leftSphere.setParent(scene);
+                const tangentVec = new Vec3();
+                const normalVec = new Vec3();
+                const positionVec = new Vec3();
 
-                const rightSphere = new Mesh(gl, { geometry: sphereGeom, program: sphereProg2 });
-                rightSphere.scale.set(0.04);
-                rightSphere.position.add(point, binormal.clone().scale(-0.12));
-                rightSphere.setParent(scene);
-            }
-
-            const tangentVec = new Vec3();
-            const normalVec = new Vec3();
-            const positionVec = new Vec3();
-
-            function update(now) {
-                const progress = (now * 0.00001) % 1;
-
-                // take current Frenet frame
-                const frameIndex = Math.floor(progress * pathSubdivisions);
-                const frameProgress = progress * pathSubdivisions % 1;
-
-                // interpolate normal from current and next frame
-                const normal1 = frenetFrames.normals[frameIndex];
-                const normal2 = frenetFrames.normals[(frameIndex + 1) % pathSubdivisions];
-                normalVec.copy(normal1).lerp(normal2, frameProgress).normalize();
-
-                // get point and tangent on path
-                path.getPointAt(progress, positionVec);
-                path.getTangentAt(progress, tangentVec);
-
-                // make the camera follow a point on the path
-                camera.up.copy(normalVec);
-                camera.position
-                    .copy(positionVec)
-                    .sub(tangentVec)
-                    .add(normalVec);
-
-                camera.lookAt(positionVec);
-
-                renderer.render({ scene, camera });
                 requestAnimationFrame(update);
+                function update(t) {
+                    requestAnimationFrame(update);
+
+                    const progress = (t * 0.00001) % 1;
+
+                    // take current Frenet frame
+                    const frameIndex = Math.floor(progress * pathSubdivisions);
+                    const frameProgress = (progress * pathSubdivisions) % 1;
+
+                    // interpolate normal from current and next frame
+                    const normal1 = frenetFrames.normals[frameIndex];
+                    const normal2 = frenetFrames.normals[(frameIndex + 1) % pathSubdivisions];
+                    normalVec.copy(normal1).lerp(normal2, frameProgress).normalize();
+
+                    // get point and tangent on path
+                    path.getPointAt(progress, positionVec);
+                    path.getTangentAt(progress, tangentVec);
+
+                    // make the camera follow a point on the path
+                    camera.up.copy(normalVec);
+                    camera.position.copy(positionVec).sub(tangentVec).add(normalVec);
+
+                    camera.lookAt(positionVec);
+
+                    renderer.render({ scene, camera });
+                }
             }
-
-            requestAnimationFrame(update);
-        }
-    </script>
-</body>
-
+        </script>
+    </body>
 </html>

--- a/examples/pbr.html
+++ b/examples/pbr.html
@@ -154,7 +154,7 @@
                     float level0 = floor(blend);
                     float level1 = min(ENV_LODS, level0 + 1.0);
                     blend -= level0;
-                    
+
                     // Sample the specular env map atlas depending on the roughness value
                     vec2 uvSpec = cartesianToPolar(reflection);
                     uvSpec.y /= 2.0;
@@ -173,7 +173,7 @@
                     vec3 specularLight = mix(specular0, specular1, blend);
 
                     diffuse = diffuseLight * diffuseColor;
-                    
+
                     // Bit of extra reflection for smooth materials
                     float reflectivity = pow((1.0 - roughness), 2.0) * 0.05;
                     specular = specularLight * (specularColor * brdf.x + brdf.y + reflectivity);
@@ -213,7 +213,7 @@
 
                     vec3 diffuseContrib = (1.0 - F) * (diffuseColor / PI);
                     vec3 specContrib = F * G * D / (4.0 * NdL * NdV);
-                    
+
                     // Shading based off lights
                     vec3 color = NdL * uLightColor * (diffuseContrib + specContrib);
 
@@ -244,7 +244,7 @@
 
                     // Convert to sRGB to display
                     gl_FragColor.rgb = linearToSRGB(color);
-                    
+
                     // Apply uAlpha uniform at the end to overwrite any specular additions on transparent surfaces
                     gl_FragColor.a = alpha * uAlpha;
                 }
@@ -385,7 +385,7 @@
                     float level0 = floor(blend);
                     float level1 = min(ENV_LODS, level0 + 1.0);
                     blend -= level0;
-                    
+
                     // Sample the specular env map atlas depending on the roughness value
                     vec2 uvSpec = cartesianToPolar(reflection);
                     uvSpec.y /= 2.0;
@@ -404,7 +404,7 @@
                     vec3 specularLight = mix(specular0, specular1, blend);
 
                     diffuse = diffuseLight * diffuseColor;
-                    
+
                     // Bit of extra reflection for smooth materials
                     float reflectivity = pow((1.0 - roughness), 2.0) * 0.05;
                     specular = specularLight * (specularColor * brdf.x + brdf.y + reflectivity);
@@ -444,7 +444,7 @@
 
                     vec3 diffuseContrib = (1.0 - F) * (diffuseColor / PI);
                     vec3 specContrib = F * G * D / (4.0 * NdL * NdV);
-                    
+
                     // Shading based off lights
                     vec3 color = NdL * uLightColor * (diffuseContrib + specContrib);
 
@@ -475,7 +475,7 @@
 
                     // Convert to sRGB to display
                     FragColor.rgb = linearToSRGB(color);
-                    
+
                     // Apply uAlpha uniform at the end to overwrite any specular additions on transparent surfaces
                     FragColor.a = alpha * uAlpha;
                 }
@@ -494,7 +494,7 @@
 
                 void main() {
                     vUv = uv;
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;
@@ -508,7 +508,7 @@
 
                 void main() {
                     float shadow = texture2D(tMap, vUv).g;
-                    
+
                     gl_FragColor.rgb = vec3(0.0);
                     gl_FragColor.a = shadow;
                 }
@@ -723,6 +723,7 @@
                     requestAnimationFrame(update);
 
                     scene.rotation.y += 0.005;
+
                     controls.update();
                     renderer.render({ scene, camera });
                 }

--- a/examples/point-lighting.html
+++ b/examples/point-lighting.html
@@ -23,7 +23,7 @@
             <a href="https://www.solarsystemscope.com/textures/" target="_blank">Solar System Scope</a>
         </div>
         <script type="module">
-            import { Renderer, Camera, Vec3, Orbit, Sphere, Transform, Geometry, Program, Mesh, Texture } from '../src/index.js';
+            import { Renderer, Camera, Vec3, Orbit, Sphere, Transform, Program, Mesh, Texture } from '../src/index.js';
 
             const VERTEX_SHADER = /* glsl */ `
                 attribute vec2 uv;
@@ -37,7 +37,6 @@
 
                 uniform vec3 u_lightWorldPosition;
                 uniform vec3 cameraPosition;
-                
 
                 varying vec3 v_normal;
                 varying vec3 v_surfaceToLight;
@@ -45,6 +44,7 @@
                 varying vec2 v_uv;
 
                 void main() {
+
                     // Pass UV information to Fragment Shader
                     v_uv = uv;
 
@@ -72,15 +72,14 @@
                 varying vec3 v_surfaceToView;
                 varying vec2 v_uv;
 
-
                 uniform float u_dt;
                 uniform float u_shininess;
                 uniform sampler2D colMap;
                 uniform sampler2D specMap;
                 uniform sampler2D cloudMap;
-                
 
                 void main() {
+
                     // Re-normalize interpolated varyings
                     vec3 normal = normalize(v_normal);
                     vec3 surfaceToLightDirection = normalize(v_surfaceToLight);
@@ -90,10 +89,10 @@
                     // This vector indecates the "brightest point"; A "refrence vector" if you will.
                     vec3 halfVector = normalize(surfaceToLightDirection + surfaceToViewDirection);
 
-                    // Then we can get the brightness at any point by seeing "how similar" 
-                    // the surface normal is to the refrence vector. 
+                    // Then we can get the brightness at any point by seeing "how similar"
+                    // the surface normal is to the refrence vector.
                     float light = dot(normal, surfaceToLightDirection);
-                    
+
                     // By raising the specular vector to a power we can control the intensity
                     // of the light
                     float specular = 0.0;
@@ -112,6 +111,7 @@
 
                     // Add Point Lighting
                     gl_FragColor.rgb *= light;
+
                     // Add Specular Highlights
                     gl_FragColor.rgb += specular * spec;
                 }
@@ -188,12 +188,12 @@
                 });
 
                 requestAnimationFrame(update);
-                function update(dt) {
+                function update(t) {
                     requestAnimationFrame(update);
 
                     mesh.rotation.y += 0.005;
 
-                    program.uniforms.u_dt.value = -dt * 0.00002;
+                    program.uniforms.u_dt.value = -t * 0.00002;
 
                     controls.update();
                     renderer.render({ scene, camera });

--- a/examples/polylines.html
+++ b/examples/polylines.html
@@ -36,10 +36,10 @@
                     vec2 aspect = vec2(uResolution.x / uResolution.y, 1);
                     vec2 nextScreen = next.xy * aspect;
                     vec2 prevScreen = prev.xy * aspect;
-                
+
                     // Calculate the tangent direction
                     vec2 tangent = normalize(nextScreen - prevScreen);
-                
+
                     // Rotate 90 degrees to get the normal
                     vec2 normal = vec2(-tangent.y, tangent.x);
                     normal /= aspect;
@@ -55,7 +55,7 @@
                     float pixelWidth = current.w * pixelWidthRatio;
                     normal *= pixelWidth * uThickness;
                     current.xy -= normal * side;
-                
+
                     return current;
                 }
 

--- a/examples/post-bloom.html
+++ b/examples/post-bloom.html
@@ -64,6 +64,7 @@
                 varying vec2 vUv;
 
                 void main() {
+
                     // Swap with blur9 for higher quality
                     // gl_FragColor = blur9(tMap, vUv, uResolution, uDirection);
                     gl_FragColor = blur5(tMap, vUv, uResolution, uDirection);
@@ -104,7 +105,7 @@
                 const resolution = { value: new Vec2() };
                 const bloomResolution = { value: new Vec2() };
 
-                const scene = new Transform(gl);
+                const scene = new Transform();
 
                 let mesh;
                 // Store this so we can toggle it on and off during render phase
@@ -137,7 +138,7 @@
                             varying vec2 vUv;
 
                             void main() {
-                            gl_FragColor = vec4(vUv, 1.0, 1.0);
+                                gl_FragColor = vec4(vUv, 1.0, 1.0);
                             }
                         `,
                     });
@@ -217,7 +218,7 @@
 
                     // This render the bloom effect's bright and blur passes to postBloom.fbo.read
                     // Passing in a `texture` argument avoids the post initially rendering the scene
-                    postBloom.render({ texture: postComposite.uniform.value, targetOnly: true });
+                    postBloom.render({ texture: postComposite.uniform.value });
 
                     // Re-enable composite pass
                     compositePass.enabled = true;

--- a/examples/post-fluid-distortion.html
+++ b/examples/post-fluid-distortion.html
@@ -18,20 +18,7 @@
             <a href="https://github.com/PavelDoGreat/WebGL-Fluid-Simulation" target="_blank">Pavel Dobryakov</a>
         </div>
         <script type="module">
-            import {
-                Renderer,
-                Camera,
-                RenderTarget,
-                Geometry,
-                Program,
-                Texture,
-                Mesh,
-                Color,
-                Vec2,
-                Box,
-                NormalProgram,
-                Post,
-            } from '../src/index.js';
+            import { Renderer, Camera, RenderTarget, Geometry, Program, Mesh, Color, Vec2, Box, NormalProgram, Post } from '../src/index.js';
 
             const fragment = /* glsl */ `
                 precision highp float;

--- a/examples/post-fxaa.html
+++ b/examples/post-fxaa.html
@@ -15,7 +15,7 @@
     <body>
         <div class="Info">Post FXAA (Fast Approximate Anti-Aliasing)</div>
         <script type="module">
-            import { Renderer, Camera, Program, Mesh, Vec2, Post, Box, NormalProgram } from '../src/index.js';
+            import { Renderer, Camera, Mesh, Vec2, Post, Box, NormalProgram } from '../src/index.js';
 
             const fragment = /* glsl */ `
                 precision highp float;
@@ -40,16 +40,16 @@
                     float lM  = dot(texture2D(tex, uv).rgb, l);
                     float lMin = min(lM, min(min(lNW, lNE), min(lSW, lSE)));
                     float lMax = max(lM, max(max(lNW, lNE), max(lSW, lSE)));
-                    
+
                     vec2 dir = vec2(
                         -((lNW + lNE) - (lSW + lSE)),
                         ((lNW + lSW) - (lNE + lSE))
                     );
-                    
+
                     float dirReduce = max((lNW + lNE + lSW + lSE) * 0.03125, 0.0078125);
                     float rcpDirMin = 1.0 / (min(abs(dir.x), abs(dir.y)) + dirReduce);
                     dir = min(vec2(8, 8), max(vec2(-8, -8), dir * rcpDirMin)) * pixel;
-                    
+
                     vec3 rgbA = 0.5 * (
                         texture2D(tex, uv + dir * (1.0 / 3.0 - 0.5)).rgb +
                         texture2D(tex, uv + dir * (2.0 / 3.0 - 0.5)).rgb);

--- a/examples/raycasting.html
+++ b/examples/raycasting.html
@@ -76,7 +76,7 @@
                 const program = new Program(gl, {
                     vertex,
                     fragment,
-                    cullFace: null,
+                    cullFace: false,
                     uniforms: {
                         uHit: { value: 0 },
                     },
@@ -105,15 +105,15 @@
                 requestAnimationFrame(update);
                 function update() {
                     requestAnimationFrame(update);
-                    orbit.update();
 
+                    orbit.update();
                     renderer.render({ scene, camera });
                 }
 
                 const mouse = new Vec2();
 
                 // Create a raycast object
-                const raycast = new Raycast(gl);
+                const raycast = new Raycast();
 
                 // Define an array of the meshes we want to test our ray against
                 const meshes = [plane, sphere, cube];

--- a/examples/render-to-texture.html
+++ b/examples/render-to-texture.html
@@ -15,7 +15,7 @@
     <body>
         <div class="Info">Render to texture</div>
         <script type="module">
-            import { Renderer, Camera, Transform, Texture, RenderTarget, Program, Mesh, Box } from '../src/index.js';
+            import { Renderer, Camera, Texture, RenderTarget, Program, Mesh, Box } from '../src/index.js';
 
             const vertex = /* glsl */ `
                 attribute vec3 position;
@@ -32,7 +32,7 @@
                 void main() {
                     vUv = uv;
                     vNormal = normalize(normalMatrix * normal);
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;

--- a/examples/scene-graph.html
+++ b/examples/scene-graph.html
@@ -30,7 +30,7 @@
 
                 void main() {
                     vNormal = normalize(normalMatrix * normal);
-                    
+
                     vMVPos = modelViewMatrix * vec4(position, 1.0);
                     gl_Position = projectionMatrix * vMVPos;
                 }
@@ -46,11 +46,11 @@
                     vec3 normal = normalize(vNormal);
                     float lighting = dot(normal, normalize(vec3(-0.3, 0.8, 0.6)));
                     vec3 color = vec3(1.0, 0.5, 0.2) * (1.0 - 0.5 * lighting) + vMVPos.xzy * 0.1;
-                    
+
                     float dist = length(vMVPos);
                     float fog = smoothstep(4.0, 10.0, dist);
                     color = mix(color, vec3(1.0), fog);
-                    
+
                     gl_FragColor.rgb = color;
                     gl_FragColor.a = 1.0;
                 }

--- a/examples/shadow-maps.html
+++ b/examples/shadow-maps.html
@@ -33,15 +33,15 @@
 
                 // Matrix to shift range from -1->1 to 0->1
                 const mat4 depthScaleMatrix = mat4(
-                    0.5, 0, 0, 0, 
-                    0, 0.5, 0, 0, 
-                    0, 0, 0.5, 0, 
+                    0.5, 0, 0, 0,
+                    0, 0.5, 0, 0,
+                    0, 0, 0.5, 0,
                     0.5, 0.5, 0.5, 1
                 );
 
                 void main() {
                     vUv = uv;
-                    
+
                     // Calculate the NDC (normalized device coords) for the light to compare against shadowmap
                     vLightNDC = depthScaleMatrix * shadowProjectionMatrix * shadowViewMatrix * modelMatrix * vec4(position, 1.0);
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
@@ -133,7 +133,7 @@
                         uniforms: {
                             tMap: { value: texture },
                         },
-                        cullFace: null,
+                        cullFace: false,
                     });
 
                     const data = await (await fetch(`assets/airplane.json`)).json();
@@ -165,7 +165,7 @@
                         uniforms: {
                             tMap: { value: texture },
                         },
-                        cullFace: null,
+                        cullFace: false,
                     });
 
                     const geometry = new Plane(gl);
@@ -184,6 +184,7 @@
                 requestAnimationFrame(update);
                 function update(t) {
                     requestAnimationFrame(update);
+
                     controls.update();
 
                     // A bit of plane animation

--- a/examples/skinning.html
+++ b/examples/skinning.html
@@ -118,7 +118,7 @@
 
                 void main() {
                     vUv = uv;
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;
@@ -132,149 +132,151 @@
 
                 void main() {
                     float shadow = texture2D(tMap, vUv).g;
-                    
+
                     gl_FragColor.rgb = vec3(0.0);
                     gl_FragColor.a = shadow;
                 }
             `;
 
-            const renderer = new Renderer({ dpr: 2 });
-            const gl = renderer.gl;
-            document.body.appendChild(gl.canvas);
-            gl.clearColor(1, 1, 1, 1);
+            {
+                const renderer = new Renderer({ dpr: 2 });
+                const gl = renderer.gl;
+                document.body.appendChild(gl.canvas);
+                gl.clearColor(1, 1, 1, 1);
 
-            const camera = new Camera(gl, { fov: 35 });
-            camera.position.set(6, 2, 6);
+                const camera = new Camera(gl, { fov: 35 });
+                camera.position.set(6, 2, 6);
 
-            const controls = new Orbit(camera);
+                const controls = new Orbit(camera);
 
-            function resize() {
-                renderer.setSize(window.innerWidth, window.innerHeight);
-                camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
-            }
-            window.addEventListener('resize', resize, false);
-            resize();
+                function resize() {
+                    renderer.setSize(window.innerWidth, window.innerHeight);
+                    camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
+                }
+                window.addEventListener('resize', resize, false);
+                resize();
 
-            const scene = new Transform();
+                const scene = new Transform();
 
-            let skin, animation;
-            loadModel();
-            async function loadModel() {
-                const data = await (await fetch(`assets/snout-rig.json`)).json();
-                // Rig JSON data format
-                // format is the same as regular model json, with the addition of the rig object
-                //
-                // {
-                //     position: [],
-                //     skinWeight: [],
-                //     ... other vertex attributes
+                let skin, animation;
+                loadModel();
+                async function loadModel() {
+                    const data = await (await fetch(`assets/snout-rig.json`)).json();
+                    // Rig JSON data format
+                    // format is the same as regular model json, with the addition of the rig object
+                    //
+                    // {
+                    //     position: [],
+                    //     skinWeight: [],
+                    //     ... other vertex attributes
 
-                //     rig: {
-                //         bones: [
-                //             {name: 'root', parent: -1},
-                //             {name: 'spine', parent: 0},
-                //             ... for whole bone hierarchy
-                //         ],
-                //         bindPose: {
-                //             ... for the following properties, values concatenated for all bones, arranged in order of bones array
-                //             position: [x1, y1, z1, x2, y2, z2, ...],
-                //             quaternion: [x1, y1, z1, w1, x2, y2, z2, w2, ...],
-                //             scale: [x1, y1, z1, x2, y2, z2, ...],
-                //         },
-                //     },
-                // }
+                    //     rig: {
+                    //         bones: [
+                    //             {name: 'root', parent: -1},
+                    //             {name: 'spine', parent: 0},
+                    //             ... for whole bone hierarchy
+                    //         ],
+                    //         bindPose: {
+                    //             ... for the following properties, values concatenated for all bones, arranged in order of bones array
+                    //             position: [x1, y1, z1, x2, y2, z2, ...],
+                    //             quaternion: [x1, y1, z1, w1, x2, y2, z2, w2, ...],
+                    //             scale: [x1, y1, z1, x2, y2, z2, ...],
+                    //         },
+                    //     },
+                    // }
 
-                const animationData = await (await fetch(`assets/snout-anim.json`)).json();
-                // Animation JSON format
-                // data is expected to be baked for each frame, therefore duration is derived
-                // from number of frames in array.
-                // {
-                //     frames: [
-                //         {
-                //             ... identical format to bindPose above, values are concatenated
-                //             position: [x1, y1, z1, x2, y2, z2, ...],
-                //             quaternion: [x1, y1, z1, w1, x2, y2, z2, w2, ...],
-                //             scale: [x1, y1, z1, x2, y2, z2, ...],
-                //         },
-                //         ... continue for number of frames
-                //     ]
-                // }
+                    const animationData = await (await fetch(`assets/snout-anim.json`)).json();
+                    // Animation JSON format
+                    // data is expected to be baked for each frame, therefore duration is derived
+                    // from number of frames in array.
+                    // {
+                    //     frames: [
+                    //         {
+                    //             ... identical format to bindPose above, values are concatenated
+                    //             position: [x1, y1, z1, x2, y2, z2, ...],
+                    //             quaternion: [x1, y1, z1, w1, x2, y2, z2, w2, ...],
+                    //             scale: [x1, y1, z1, x2, y2, z2, ...],
+                    //         },
+                    //         ... continue for number of frames
+                    //     ]
+                    // }
 
-                const geometry = new Geometry(gl, {
-                    position: { size: 3, data: new Float32Array(data.position) },
-                    uv: { size: 2, data: new Float32Array(data.uv) },
-                    normal: { size: 3, data: new Float32Array(data.normal) },
-                    skinIndex: { size: 4, data: new Float32Array(data.skinIndex) },
-                    skinWeight: { size: 4, data: new Float32Array(data.skinWeight) },
-                });
+                    const geometry = new Geometry(gl, {
+                        position: { size: 3, data: new Float32Array(data.position) },
+                        uv: { size: 2, data: new Float32Array(data.uv) },
+                        normal: { size: 3, data: new Float32Array(data.normal) },
+                        skinIndex: { size: 4, data: new Float32Array(data.skinIndex) },
+                        skinWeight: { size: 4, data: new Float32Array(data.skinWeight) },
+                    });
 
-                const texture = new Texture(gl);
-                const img = new Image();
-                img.onload = () => (texture.image = img);
-                img.src = 'assets/snout.jpg';
+                    const texture = new Texture(gl);
+                    const img = new Image();
+                    img.onload = () => (texture.image = img);
+                    img.src = 'assets/snout.jpg';
 
-                const program = new Program(gl, {
-                    vertex,
-                    fragment,
-                    uniforms: {
-                        tMap: { value: texture },
-                    },
-                });
+                    const program = new Program(gl, {
+                        vertex,
+                        fragment,
+                        uniforms: {
+                            tMap: { value: texture },
+                        },
+                    });
 
-                // Skin extends Mesh - so on top of passing in geometry and program,
-                // pass in the rig data, including a list of bones and their bind transforms.
-                // The Skin class will automatically add 'boneTexture' and 'boneTextureSize' uniforms.
-                skin = new Skin(gl, { rig: data.rig, geometry, program });
-                skin.setParent(scene);
+                    // Skin extends Mesh - so on top of passing in geometry and program,
+                    // pass in the rig data, including a list of bones and their bind transforms.
+                    // The Skin class will automatically add 'boneTexture' and 'boneTextureSize' uniforms.
+                    skin = new Skin(gl, { rig: data.rig, geometry, program });
+                    skin.setParent(scene);
 
-                skin.scale.set(0.01);
-                skin.position.y = -1;
+                    skin.scale.set(0.01);
+                    skin.position.y = -1;
 
-                // Helper function to add animation to skin's bones.
-                // The Animation class can be used directly for any hierarchy - is not solely for bones.
-                animation = skin.addAnimation(animationData);
-            }
+                    // Helper function to add animation to skin's bones.
+                    // The Animation class can be used directly for any hierarchy - is not solely for bones.
+                    animation = skin.addAnimation(animationData);
+                }
 
-            // Added baked occlusion on the floor to help ground the character
-            initShadow();
-            function initShadow() {
-                const texture = new Texture(gl);
-                const img = new Image();
-                img.onload = () => (texture.image = img);
-                img.src = 'assets/snout-shadow.jpg';
+                // Added baked occlusion on the floor to help ground the character
+                initShadow();
+                function initShadow() {
+                    const texture = new Texture(gl);
+                    const img = new Image();
+                    img.onload = () => (texture.image = img);
+                    img.src = 'assets/snout-shadow.jpg';
 
-                const geometry = new Plane(gl, { width: 7, height: 7 });
-                const program = new Program(gl, {
-                    vertex: shadowVertex,
-                    fragment: shadowFragment,
-                    uniforms: {
-                        tMap: { value: texture },
-                    },
-                    transparent: true,
-                    cullFace: false,
-                });
+                    const geometry = new Plane(gl, { width: 7, height: 7 });
+                    const program = new Program(gl, {
+                        vertex: shadowVertex,
+                        fragment: shadowFragment,
+                        uniforms: {
+                            tMap: { value: texture },
+                        },
+                        transparent: true,
+                        cullFace: false,
+                    });
 
-                const mesh = new Mesh(gl, { geometry, program });
-                mesh.rotation.x = -Math.PI / 2;
-                mesh.position.y = -1;
-                mesh.setParent(scene);
-            }
+                    const mesh = new Mesh(gl, { geometry, program });
+                    mesh.rotation.x = -Math.PI / 2;
+                    mesh.position.y = -1;
+                    mesh.setParent(scene);
+                }
 
-            requestAnimationFrame(update);
-            function update(t) {
                 requestAnimationFrame(update);
+                function update(t) {
+                    requestAnimationFrame(update);
 
-                // Control animation but updating the elapsed value.
-                // It uses modulo to repeat the animation range,
-                // so below is playing a never-ending loop.
-                if (animation) animation.elapsed += 0.1;
+                    // Control animation but updating the elapsed value.
+                    // It uses modulo to repeat the animation range,
+                    // so below is playing a never-ending loop.
+                    if (animation) animation.elapsed += 0.1;
 
-                // Calling 'update' updates the bones with all of the
-                // attached animations based on their weights.
-                if (skin) skin.update();
+                    // Calling 'update' updates the bones with all of the
+                    // attached animations based on their weights.
+                    if (skin) skin.update();
 
-                controls.update();
-                renderer.render({ scene, camera });
+                    controls.update();
+                    renderer.render({ scene, camera });
+                }
             }
         </script>
     </body>

--- a/examples/skydome.html
+++ b/examples/skydome.html
@@ -17,7 +17,7 @@
             Skydome. Image credit <a href="https://www.flickr.com/photos/charlesashaw/6264765128" target="_blank">charlesashaw</a>.
         </div>
         <script type="module">
-            import { Renderer, Geometry, Program, Mesh, Camera, Transform, Texture, Sphere, Orbit } from '../src/index.js';
+            import { Renderer, Program, Mesh, Camera, Transform, Texture, Sphere, Orbit } from '../src/index.js';
 
             const vertex = /* glsl */ `
                 attribute vec2 uv;
@@ -44,7 +44,7 @@
 
                 void main() {
                     vec3 tex = texture2D(tMap, vUv).rgb;
-                    
+
                     gl_FragColor.rgb = tex;
                     gl_FragColor.a = 1.0;
                 }
@@ -90,7 +90,7 @@
                     },
 
                     // Need inside of sphere to be visible
-                    cullFace: null,
+                    cullFace: false,
                 });
 
                 // A smaller sphere in the center just to help illustrate

--- a/examples/sort-transparency.html
+++ b/examples/sort-transparency.html
@@ -48,13 +48,13 @@
 
                 void main() {
                     float alpha = texture2D(tMap, vUv).g;
-                    
+
                     vec3 color = uColor + vMVPos.xzy * 0.05;
-                    
+
                     float dist = length(vMVPos);
                     float fog = smoothstep(5.0, 10.0, dist);
                     color = mix(color, vec3(1.0), fog);
-                    
+
                     gl_FragColor.rgb = color;
                     gl_FragColor.a = alpha;
                     if (alpha < 0.01) discard;
@@ -101,7 +101,7 @@
                         uColor: { value: new Color('#ffc219') },
                     },
                     transparent: true,
-                    cullFace: null,
+                    cullFace: false,
                 });
 
                 const meshes = [];

--- a/examples/textures.html
+++ b/examples/textures.html
@@ -15,7 +15,7 @@
     <body>
         <div class="Info">Textures. Model by Google Poly. Film by Studio Ghibli.</div>
         <script type="module">
-            import { Renderer, Camera, Transform, Texture, TextureLoader, Program, Geometry, Mesh, Box } from '../src/index.js';
+            import { Renderer, Camera, Transform, Texture, Program, Geometry, Mesh, Box } from '../src/index.js';
 
             const vertex = /* glsl */ `
                 attribute vec2 uv;
@@ -32,7 +32,7 @@
                 void main() {
                     vUv = uv;
                     vNormal = normalize(normalMatrix * normal);
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;
@@ -48,10 +48,10 @@
                 void main() {
                     vec3 normal = normalize(vNormal);
                     vec3 tex = texture2D(tMap, vUv).rgb;
-                    
+
                     vec3 light = normalize(vec3(0.5, 1.0, -0.3));
                     float shading = dot(normal, light) * 0.15;
-                    
+
                     gl_FragColor.rgb = tex + shading;
                     gl_FragColor.a = 1.0;
                 }
@@ -139,7 +139,7 @@
                     uniforms: {
                         tMap: { value: videoTexture },
                     },
-                    cullFace: null,
+                    cullFace: false,
                 });
                 const videoMesh = new Mesh(gl, {
                     geometry: videoGeometry,

--- a/examples/torus.html
+++ b/examples/torus.html
@@ -82,12 +82,12 @@
                 requestAnimationFrame(update);
                 function update() {
                     requestAnimationFrame(update);
+
                     torus.rotation.x += 0.001;
                     torus.rotation.y += 0.005;
                     torus.rotation.z += 0.003;
 
                     controls.update();
-
                     renderer.render({ scene, camera });
                 }
             }

--- a/examples/tube.html
+++ b/examples/tube.html
@@ -1,148 +1,172 @@
 <!DOCTYPE html>
 <html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+        <meta
+            name="viewport"
+            content="width=device-width, minimal-ui, viewport-fit=cover, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no"
+        />
+        <link rel="icon" type="image/png" href="assets/favicon.png" />
 
-<head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport"
-        content="width=device-width, minimal-ui, viewport-fit=cover, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
-    <link rel="icon" type="image/png" href="assets/favicon.png" />
+        <title>OGL • Tube</title>
+        <link href="assets/main.css" rel="stylesheet" />
+    </head>
+    <body>
+        <div class="Info">Tube</div>
+        <script type="module">
+            import { Renderer, Camera, Transform, Program, Mesh, Sphere, Orbit, Vec3, Color, Path, Tube } from '../src/index.js';
 
-    <title>OGL • Tube</title>
-    <link href="assets/main.css" rel="stylesheet" />
-</head>
+            const vertexColor = /* glsl */ `
+                attribute vec3 position;
+                attribute vec3 normal;
 
-<body>
-    <div class="Info">Tube</div>
-    <script type="module">
-        import { Renderer, Camera, Transform, Program, Mesh, Sphere, Polyline, Orbit, Vec3, Color, Path, Tube } from '../src/index.js';
+                uniform mat4 modelViewMatrix;
+                uniform mat4 projectionMatrix;
+                uniform mat3 normalMatrix;
 
-        const vertexColor = /* glsl */ `
-            attribute vec3 position;
-            attribute vec3 normal;
+                varying vec3 vNormal;
 
-            uniform mat4 modelViewMatrix;
-            uniform mat4 projectionMatrix;
-            uniform mat3 normalMatrix;
-
-            varying vec3 vNormal;
-
-            void main() {
-                vNormal = normalize(normalMatrix * normal);
-                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-            }`;
-
-        const fragmentColor = /* glsl */ `
-            precision highp float;
-            uniform vec3 uColor;
-            varying vec3 vNormal;
-
-            void main() {
-                vec3 normal = normalize(vNormal);
-                float lighting = dot(normal, normalize(vec3(-0.3, 0.8, 0.6)));
-                gl_FragColor.rgb = uColor + lighting * 0.1;
-                gl_FragColor.a = 1.0;
-            }`;
-
-        const vertexUv = /* glsl */ `
-            attribute vec3 position;
-            attribute vec2 uv;
-            uniform mat4 modelViewMatrix;
-            uniform mat4 projectionMatrix;
-            varying vec2 vUv;
-
-            void main() {
-                vUv = uv;
-                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-            }`;
-
-        const fragmentUv = /* glsl */ `
-            precision highp float;
-            varying vec2 vUv;
-
-            void main() {
-                if (cos(vUv.x * 512.0) < 0.0) discard;
-                gl_FragColor.rgb = vec3(cos(vUv * 6.283185307179586) * 0.5 + 0.5, 1.0);
-                gl_FragColor.a = 1.0;
-            }`;
-
-        {
-            const renderer = new Renderer({ dpr: 2 });
-            const gl = renderer.gl;
-            document.body.appendChild(gl.canvas);
-            gl.clearColor(1, 1, 1, 1);
-
-            const camera = new Camera(gl, { fov: 35 });
-            camera.position.set(0, 0, 5);
-
-            // Create controls and pass parameters
-            const controls = new Orbit(camera, {
-                target: new Vec3(0, 0, 0),
-            });
-
-            function resize() {
-                renderer.setSize(window.innerWidth, window.innerHeight);
-                camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
-            }
-            window.addEventListener('resize', resize, false);
-            resize();
-
-            const scene = new Transform();
-
-            // First three is for moveTo command, rest for bezierCurveTo command
-            const pathCoords = [-1.0, 0.0, 0.0, -0.9368709325790405, 0.1762027144432068, 0.04529910162091255, -0.7061498761177063, 0.089231938123703, 0.19381383061408997, -0.6332840919494629, 0.2674865424633026, 0.1930660903453827, -0.5615311861038208, 0.4430185854434967, 0.1923297792673111, -0.7734173536300659, 0.5522762537002563, 0.08718681335449219, -0.7070468664169312, 0.7070468664169312, 0.0, -0.6498651504516602, 0.8403899073600769, -0.07511603832244873, -0.5399253368377686, 0.8584117889404297, -0.16668838262557983, -0.38917776942253113, 0.921392560005188, -0.1677459478378296, -0.23391252756118774, 0.9862607717514038, -0.16883520781993866, -0.14611071348190308, 1.0727460384368896, -0.04093937203288078, 0.0, 1.0, 0.0, 0.1674281358718872, 0.9166403412818909, 0.046912387013435364, 0.07777689397335052, 0.6478093862533569, -0.06732462346553802, 0.2400655597448349, 0.5683639645576477, 0.0, 0.4298238456249237, 0.4754713177680969, 0.07872024923563004, 0.49316900968551636, 0.7766210436820984, 0.32597726583480835, 0.7070468664169312, 0.7070468664169312, 0.3101717531681061, 0.8896822333335876, 0.647635817527771, 0.29667505621910095, 0.8556811809539795, 0.5579423308372498, 0.06533028930425644, 0.921392560005188, 0.38917776942253113, 0.0, 0.9742976427078247, 0.2533031702041626, -0.05259828269481659, 1.0508142709732056, 0.14183028042316437, -0.036462459713220596, 1.0, 0.0, 0.0, 0.9368709325790405, -0.1762027144432068, 0.04529910162091255, 0.7061498761177063, -0.089231938123703, 0.19381383061408997, 0.6332840919494629, -0.2674865424633026, 0.1930660903453827, 0.5615311861038208, -0.4430185854434967, 0.1923297792673111, 0.7734173536300659, -0.5522762537002563, 0.08718681335449219, 0.7070468664169312, -0.7070468664169312, 0.0, 0.6498651504516602, -0.8403899073600769, -0.07511603832244873, 0.5399253368377686, -0.8584117889404297, -0.16668838262557983, 0.38917776942253113, -0.921392560005188, -0.1677459478378296, 0.23391252756118774, -0.9862607717514038, -0.16883520781993866, 0.14611071348190308, -1.0727460384368896, -0.04093937203288078, 0.0, -1.0, 0.0, -0.1674281358718872, -0.9166403412818909, 0.046912387013435364, -0.07777689397335052, -0.6478093862533569, -0.06732462346553802, -0.2400655597448349, -0.5683639645576477, 0.0, -0.4298238456249237, -0.4754713177680969, 0.07872024923563004, -0.49316900968551636, -0.7766210436820984, 0.32597726583480835, -0.7070468664169312, -0.7070468664169312, 0.3101717531681061, -0.8896822333335876, -0.647635817527771, 0.29667505621910095, -0.8556811809539795, -0.5579423308372498, 0.06533028930425644, -0.921392560005188, -0.38917776942253113, 0.0, -0.9742976427078247, -0.2533031702041626, -0.05259828269481659, -1.0508142709732056, -0.14183028042316437, -0.036462459713220596, -1.0, 0.0, 0.0];
-
-            const path = new Path();
-            path.tiltFunction = (angle, t, path) => 8 * 360 * t;
-
-            path.moveTo(new Vec3(pathCoords[0], pathCoords[1], pathCoords[2]));
-            for (let i = 3; i < pathCoords.length; i += 9) {
-                const cp1 = new Vec3(pathCoords[i + 0], pathCoords[i + 1], pathCoords[i + 2]);
-                const cp2 = new Vec3(pathCoords[i + 3], pathCoords[i + 4], pathCoords[i + 5]);
-                const p = new Vec3(pathCoords[i + 6], pathCoords[i + 7], pathCoords[i + 8]);
-                path.bezierCurveTo(cp1, cp2, p);
-            }
-
-            const pathSubdivisions = 256;
-            const points = path.getPoints(pathSubdivisions);
-
-            const frenetFrames = path.computeFrenetFrames(pathSubdivisions, true);
-
-            const tubeGeom = new Tube(gl, { path, radius: 0.1, tubularSegments: 256, radialSegments: 16, closed: true });
-            const tubeProg = new Program(gl, {
-                vertex: vertexUv,
-                fragment: fragmentUv,
-                cullFace: null
-            });
-            const tubeMesh = new Mesh(gl, { geometry: tubeGeom, program: tubeProg });
-            tubeMesh.setParent(scene);
-
-            const sphereGeom = new Sphere(gl);
-            const sphereProg = new Program(gl, {
-                vertex: vertexColor,
-                fragment: fragmentColor,
-                uniforms: {
-                    uColor: { value: new Color('#4caf50') }
+                void main() {
+                    vNormal = normalize(normalMatrix * normal);
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
-            });
+            `;
 
-            const sphereMesh = new Mesh(gl, { geometry: sphereGeom, program: sphereProg });
-            sphereMesh.scale.set(0.1);
-            sphereMesh.setParent(scene);
+            const fragmentColor = /* glsl */ `
+                precision highp float;
+                uniform vec3 uColor;
+                varying vec3 vNormal;
 
-            function update(now) {
-                const progress = (now * 0.0001) % 1;
-                controls.update();
+                void main() {
+                    vec3 normal = normalize(vNormal);
+                    float lighting = dot(normal, normalize(vec3(-0.3, 0.8, 0.6)));
+                    gl_FragColor.rgb = uColor + lighting * 0.1;
+                    gl_FragColor.a = 1.0;
+                }
+            `;
 
-                path.getPointAt(progress, sphereMesh.position);
+            const vertexUv = /* glsl */ `
+                attribute vec3 position;
+                attribute vec2 uv;
+                uniform mat4 modelViewMatrix;
+                uniform mat4 projectionMatrix;
+                varying vec2 vUv;
 
-                renderer.render({ scene, camera });
+                void main() {
+                    vUv = uv;
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `;
+
+            const fragmentUv = /* glsl */ `
+                precision highp float;
+                varying vec2 vUv;
+
+                void main() {
+                    if (cos(vUv.x * 512.0) < 0.0) discard;
+                    gl_FragColor.rgb = vec3(cos(vUv * 6.283185307179586) * 0.5 + 0.5, 1.0);
+                    gl_FragColor.a = 1.0;
+                }
+            `;
+
+            {
+                const renderer = new Renderer({ dpr: 2 });
+                const gl = renderer.gl;
+                document.body.appendChild(gl.canvas);
+                gl.clearColor(1, 1, 1, 1);
+
+                const camera = new Camera(gl, { fov: 35 });
+                camera.position.set(0, 0, 5);
+
+                // Create controls and pass parameters
+                const controls = new Orbit(camera, {
+                    target: new Vec3(0, 0, 0),
+                });
+
+                function resize() {
+                    renderer.setSize(window.innerWidth, window.innerHeight);
+                    camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
+                }
+                window.addEventListener('resize', resize, false);
+                resize();
+
+                const scene = new Transform();
+
+                // First three is for moveTo command, rest for bezierCurveTo command
+                const pathCoords = [
+                    -1.0, 0.0, 0.0, -0.9368709325790405, 0.1762027144432068, 0.04529910162091255, -0.7061498761177063, 0.089231938123703,
+                    0.19381383061408997, -0.6332840919494629, 0.2674865424633026, 0.1930660903453827, -0.5615311861038208, 0.4430185854434967,
+                    0.1923297792673111, -0.7734173536300659, 0.5522762537002563, 0.08718681335449219, -0.7070468664169312, 0.7070468664169312, 0.0,
+                    -0.6498651504516602, 0.8403899073600769, -0.07511603832244873, -0.5399253368377686, 0.8584117889404297, -0.16668838262557983,
+                    -0.38917776942253113, 0.921392560005188, -0.1677459478378296, -0.23391252756118774, 0.9862607717514038, -0.16883520781993866,
+                    -0.14611071348190308, 1.0727460384368896, -0.04093937203288078, 0.0, 1.0, 0.0, 0.1674281358718872, 0.9166403412818909,
+                    0.046912387013435364, 0.07777689397335052, 0.6478093862533569, -0.06732462346553802, 0.2400655597448349, 0.5683639645576477, 0.0,
+                    0.4298238456249237, 0.4754713177680969, 0.07872024923563004, 0.49316900968551636, 0.7766210436820984, 0.32597726583480835,
+                    0.7070468664169312, 0.7070468664169312, 0.3101717531681061, 0.8896822333335876, 0.647635817527771, 0.29667505621910095,
+                    0.8556811809539795, 0.5579423308372498, 0.06533028930425644, 0.921392560005188, 0.38917776942253113, 0.0, 0.9742976427078247,
+                    0.2533031702041626, -0.05259828269481659, 1.0508142709732056, 0.14183028042316437, -0.036462459713220596, 1.0, 0.0, 0.0,
+                    0.9368709325790405, -0.1762027144432068, 0.04529910162091255, 0.7061498761177063, -0.089231938123703, 0.19381383061408997,
+                    0.6332840919494629, -0.2674865424633026, 0.1930660903453827, 0.5615311861038208, -0.4430185854434967, 0.1923297792673111,
+                    0.7734173536300659, -0.5522762537002563, 0.08718681335449219, 0.7070468664169312, -0.7070468664169312, 0.0, 0.6498651504516602,
+                    -0.8403899073600769, -0.07511603832244873, 0.5399253368377686, -0.8584117889404297, -0.16668838262557983, 0.38917776942253113,
+                    -0.921392560005188, -0.1677459478378296, 0.23391252756118774, -0.9862607717514038, -0.16883520781993866, 0.14611071348190308,
+                    -1.0727460384368896, -0.04093937203288078, 0.0, -1.0, 0.0, -0.1674281358718872, -0.9166403412818909, 0.046912387013435364,
+                    -0.07777689397335052, -0.6478093862533569, -0.06732462346553802, -0.2400655597448349, -0.5683639645576477, 0.0,
+                    -0.4298238456249237, -0.4754713177680969, 0.07872024923563004, -0.49316900968551636, -0.7766210436820984, 0.32597726583480835,
+                    -0.7070468664169312, -0.7070468664169312, 0.3101717531681061, -0.8896822333335876, -0.647635817527771, 0.29667505621910095,
+                    -0.8556811809539795, -0.5579423308372498, 0.06533028930425644, -0.921392560005188, -0.38917776942253113, 0.0, -0.9742976427078247,
+                    -0.2533031702041626, -0.05259828269481659, -1.0508142709732056, -0.14183028042316437, -0.036462459713220596, -1.0, 0.0, 0.0,
+                ];
+
+                const path = new Path();
+                path.tiltFunction = (angle, t, path) => 8 * 360 * t;
+
+                path.moveTo(new Vec3(pathCoords[0], pathCoords[1], pathCoords[2]));
+                for (let i = 3; i < pathCoords.length; i += 9) {
+                    const cp1 = new Vec3(pathCoords[i + 0], pathCoords[i + 1], pathCoords[i + 2]);
+                    const cp2 = new Vec3(pathCoords[i + 3], pathCoords[i + 4], pathCoords[i + 5]);
+                    const p = new Vec3(pathCoords[i + 6], pathCoords[i + 7], pathCoords[i + 8]);
+                    path.bezierCurveTo(cp1, cp2, p);
+                }
+
+                const pathSubdivisions = 256;
+                path.getPoints(pathSubdivisions);
+                path.computeFrenetFrames(pathSubdivisions, true);
+
+                const tubeGeom = new Tube(gl, { path, radius: 0.1, tubularSegments: 256, radialSegments: 16, closed: true });
+                const tubeProg = new Program(gl, {
+                    vertex: vertexUv,
+                    fragment: fragmentUv,
+                    cullFace: false,
+                });
+                const tubeMesh = new Mesh(gl, { geometry: tubeGeom, program: tubeProg });
+                tubeMesh.setParent(scene);
+
+                const sphereGeom = new Sphere(gl);
+                const sphereProg = new Program(gl, {
+                    vertex: vertexColor,
+                    fragment: fragmentColor,
+                    uniforms: {
+                        uColor: { value: new Color('#4caf50') },
+                    },
+                });
+
+                const sphereMesh = new Mesh(gl, { geometry: sphereGeom, program: sphereProg });
+                sphereMesh.scale.set(0.1);
+                sphereMesh.setParent(scene);
+
                 requestAnimationFrame(update);
+                function update(t) {
+                    requestAnimationFrame(update);
+
+                    const progress = (t * 0.0001) % 1;
+                    path.getPointAt(progress, sphereMesh.position);
+
+                    controls.update();
+                    renderer.render({ scene, camera });
+                }
             }
-
-            requestAnimationFrame(update);
-        }
-    </script>
-</body>
-
+        </script>
+    </body>
 </html>

--- a/examples/wire-mesh.html
+++ b/examples/wire-mesh.html
@@ -1,80 +1,81 @@
 <!DOCTYPE html>
 <html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+        <meta
+            name="viewport"
+            content="width=device-width, minimal-ui, viewport-fit=cover, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no"
+        />
+        <link rel="icon" type="image/png" href="assets/favicon.png" />
 
-<head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport"
-        content="width=device-width, minimal-ui, viewport-fit=cover, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
-    <link rel="icon" type="image/png" href="assets/favicon.png" />
+        <title>OGL • WireMesh</title>
+        <link href="assets/main.css" rel="stylesheet" />
+    </head>
+    <body>
+        <div class="Info">WireMesh (wireframe). Model by Google Poly</div>
+        <script type="module">
+            import { Renderer, Camera, Orbit, Transform, Geometry, WireMesh, Cylinder, Vec3, Color, NormalProgram } from '../src/index.js';
 
-    <title>OGL • WireMesh</title>
-    <link href="assets/main.css" rel="stylesheet" />
-</head>
+            {
+                main();
+                async function main() {
+                    const modelData = await fetch('./assets/fox.json').then((r) => r.json());
 
-<body>
-    <div class="Info">WireMesh (wireframe). Model by Google Poly</div>
-    <script type="module">
-        import { Renderer, Camera, Orbit, Transform, Geometry, Program, Mesh, WireMesh, Cylinder, Vec3, NormalProgram } from '../src/index.js';
-        {
-            main();
-            async function main() {
-                const modelData = await fetch('./assets/fox.json').then(r => r.json());
+                    const renderer = new Renderer();
+                    const gl = renderer.gl;
+                    document.body.appendChild(gl.canvas);
+                    gl.clearColor(1, 1, 1, 1);
 
-                const renderer = new Renderer();
-                const gl = renderer.gl;
-                document.body.appendChild(gl.canvas);
-                gl.clearColor(1, 1, 1, 1);
+                    const camera = new Camera(gl, { fov: 15 });
+                    camera.position.set(15, 4, 20);
 
-                const camera = new Camera(gl, { fov: 15 });
-                camera.position.set(15, 4, 20);
+                    const controls = new Orbit(camera, {
+                        target: new Vec3(0, 0, 0),
+                    });
 
-                const controls = new Orbit(camera, {
-                    target: new Vec3(0, 0, 0),
-                });
+                    function resize() {
+                        renderer.setSize(window.innerWidth, window.innerHeight);
+                        camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
+                    }
+                    window.addEventListener('resize', resize, false);
+                    resize();
 
-                function resize() {
-                    renderer.setSize(window.innerWidth, window.innerHeight);
-                    camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
-                }
-                window.addEventListener('resize', resize, false);
-                resize();
+                    const scene = new Transform();
 
-                const scene = new Transform();
+                    const cylinderGeometry = new Cylinder(gl);
 
-                const cylinderGeometry = new Cylinder(gl);
+                    /* Just switch between Mesh and WireMesh to see mesh wireframe.
+                    In WireMesh `program` property are not required and will be ignored */
+                    // const cylinderMesh = new Mesh(gl, { geometry: cylinderGeometry, program: new NormalProgram(gl) });
+                    const cylinderMesh = new WireMesh(gl, { geometry: cylinderGeometry, program: new NormalProgram(gl) });
+                    cylinderMesh.setParent(scene);
+                    cylinderMesh.position.y = 1.5;
 
-                /* Just switch between Mesh and WireMesh to see mesh wireframe.
-                   In WireMesh `program` property are not required and will be ignored */
-                // const cylinderMesh = new Mesh(gl, { geometry: cylinderGeometry, program: new NormalProgram(gl) });
-                const cylinderMesh = new WireMesh(gl, { geometry: cylinderGeometry, program: new NormalProgram(gl) });
-                cylinderMesh.setParent(scene);
-                cylinderMesh.position.y = 1.5;
+                    const modelGeometry = new Geometry(gl, {
+                        position: { size: 3, data: new Float32Array(modelData.position) },
+                        normal: { size: 3, data: new Float32Array(modelData.normal) },
+                        uv: { size: 2, data: new Float32Array(modelData.uv) },
+                    });
 
-                const modelGeometry = new Geometry(gl, {
-                    position: { size: 3, data: new Float32Array(modelData.position), },
-                    normal: { size: 3, data: new Float32Array(modelData.normal), },
-                    uv: { size: 2, data: new Float32Array(modelData.uv), }
-                });
+                    /* Use wireColor to change wire color */
+                    // const modelMesh = new Mesh(gl, { geometry: modelGeometry, program: new NormalProgram(gl) });
+                    const modelMesh = new WireMesh(gl, { geometry: modelGeometry, wireColor: new Color(1, 0.75, 0) });
+                    modelMesh.setParent(scene);
+                    modelMesh.scale.set(0.75, 0.75, 0.75);
+                    modelMesh.position.y = -1.5;
 
-                /* Use wireColor to change wire color */
-                // const modelMesh = new Mesh(gl, { geometry: modelGeometry, program: new NormalProgram(gl) });
-                const modelMesh = new WireMesh(gl, { geometry: modelGeometry, wireColor: new Vec3(1, 0.75, 0) });
-                modelMesh.setParent(scene);
-                modelMesh.scale.set(0.75, 0.75, 0.75);
-                modelMesh.position.y = -1.5;
-
-                requestAnimationFrame(update);
-                function update(t) {
-                    scene.rotation.y += -0.005;
-                    controls.update();
-                    renderer.render({ scene, camera });
                     requestAnimationFrame(update);
+                    function update(t) {
+                        requestAnimationFrame(update);
+
+                        scene.rotation.y += -0.005;
+
+                        controls.update();
+                        renderer.render({ scene, camera });
+                    }
                 }
             }
-
-        }
-    </script>
-</body>
-
+        </script>
+    </body>
 </html>

--- a/examples/wireframe-shader.html
+++ b/examples/wireframe-shader.html
@@ -15,7 +15,7 @@
     <body>
         <div class="Info">Wireframe Shader. Model by Google Poly</div>
         <script type="module">
-            import { Renderer, Camera, Transform, Texture, Program, Geometry, Mesh, Vec3, Orbit } from '../src/index.js';
+            import { Renderer, Camera, Transform, Program, Geometry, Mesh, Vec3, Orbit } from '../src/index.js';
 
             const vertex100 = /* glsl */ `
                 attribute vec3 position;
@@ -133,7 +133,7 @@
                     vertex: renderer.isWebgl2 ? vertex300 : vertex100,
                     fragment: renderer.isWebgl2 ? fragment300 : fragment100,
                     transparent: true,
-                    cullFace: null,
+                    cullFace: false,
                     depthTest: false,
                 });
 
@@ -169,8 +169,8 @@
                 function update() {
                     requestAnimationFrame(update);
 
-                    controls.update();
                     if (mesh) mesh.rotation.y += 0.005;
+                    controls.update();
                     renderer.render({ scene, camera });
                 }
             }

--- a/examples/wireframe.html
+++ b/examples/wireframe.html
@@ -32,7 +32,7 @@
                 void main() {
                     vUv = uv;
                     vNormal = normalize(normalMatrix * normal);
-                    
+
                     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
                 }
             `;
@@ -49,7 +49,7 @@
                 void main() {
                     vec3 normal = normalize(vNormal);
                     vec3 tex = texture2D(tMap, vUv).rgb;
-                    
+
                     vec3 light = normalize(vec3(0.5, 1.0, -0.3));
                     float shading = dot(normal, light) * 0.15;
                     gl_FragColor.rgb = tex + shading;

--- a/src/core/Renderer.js
+++ b/src/core/Renderer.js
@@ -55,7 +55,7 @@ export class Renderer {
         this.state = {};
         this.state.blendFunc = { src: this.gl.ONE, dst: this.gl.ZERO };
         this.state.blendEquation = { modeRGB: this.gl.FUNC_ADD };
-        this.state.cullFace = null;
+        this.state.cullFace = false;
         this.state.frontFace = this.gl.CCW;
         this.state.depthMask = true;
         this.state.depthFunc = this.gl.LESS;

--- a/src/extras/GLTFLoader.js
+++ b/src/extras/GLTFLoader.js
@@ -77,7 +77,7 @@ export class GLTFLoader {
         // load main description json
         const desc = await this.parseDesc(src);
 
-        return await this.parse(gl, desc, dir);
+        return this.parse(gl, desc, dir);
     }
 
     static async parse(gl, desc, dir) {
@@ -144,11 +144,11 @@ export class GLTFLoader {
         };
     }
 
-    static async parseDesc(src) {
+    static parseDesc(src) {
         if (!src.match(/\.glb/)) {
-            return await fetch(src).then((res) => res.json());
+            return fetch(src).then((res) => res.json());
         } else {
-            return await fetch(src)
+            return fetch(src)
                 .then((res) => res.arrayBuffer())
                 .then((glb) => this.unpackGLB(glb));
         }
@@ -213,9 +213,9 @@ export class GLTFLoader {
         return dir + uri;
     }
 
-    static async loadBuffers(desc, dir) {
+    static loadBuffers(desc, dir) {
         if (!desc.buffers) return null;
-        return await Promise.all(
+        return Promise.all(
             desc.buffers.map((buffer) => {
                 // For GLB, binary buffer ready to go
                 if (buffer.binary) return buffer.binary;
@@ -290,9 +290,9 @@ export class GLTFLoader {
         return bufferViews;
     }
 
-    static async parseImages(gl, desc, dir, bufferViews) {
+    static parseImages(gl, desc, dir, bufferViews) {
         if (!desc.images) return null;
-        return await Promise.all(
+        return Promise.all(
             desc.images.map(async ({ uri, bufferView: bufferViewIndex, mimeType, name }) => {
                 if (mimeType === 'image/ktx2') {
                     const { data } = bufferViews[bufferViewIndex];

--- a/src/extras/InstancedMesh.js
+++ b/src/extras/InstancedMesh.js
@@ -55,7 +55,7 @@ export class InstancedMesh extends Mesh {
             // update instanceMatrix and instancedCount with visible
             this.instanceRenderList.forEach((transform, i) => {
                 transform.matrix.toArray(this.geometry.attributes.instanceMatrix.data, i * 16);
-                
+
                 // Update lightmap attr
                 if (transform.lightmapData) {
                     transform.lightmapData.toArray(this.geometry.attributes.lightmapScaleOffset.data, i * 4);

--- a/src/extras/NormalProgram.js
+++ b/src/extras/NormalProgram.js
@@ -35,6 +35,6 @@ export function NormalProgram(gl) {
     return new Program(gl, {
         vertex: vertex,
         fragment: fragment,
-        cullFace: null,
+        cullFace: false,
     });
 }

--- a/src/extras/Path/CubicBezierSegment.js
+++ b/src/extras/Path/CubicBezierSegment.js
@@ -1,6 +1,6 @@
 import BaseSegment from './BaseSegment.js';
 import { Vec3 } from '../../math/Vec3.js';
-import { T_VALUES, C_VALUES } from "./utils.js";
+import { T_VALUES, C_VALUES } from './utils.js';
 
 const tempVec3 = new Vec3();
 
@@ -35,7 +35,7 @@ export default class CubicBezierSegment extends BaseSegment {
 
         this.tiltStart = tiltStart;
         this.tiltEnd = tiltEnd;
-        
+
         this._len = -1;
     }
 

--- a/src/extras/Path/LineSegment.js
+++ b/src/extras/Path/LineSegment.js
@@ -12,7 +12,7 @@ export default class LineSegment extends BaseSegment {
 
         this.tiltStart = tiltStart;
         this.tiltEnd = tiltEnd;
-        
+
         this._len = -1;
     }
 

--- a/src/extras/Path/QuadraticBezierSegment.js
+++ b/src/extras/Path/QuadraticBezierSegment.js
@@ -1,12 +1,12 @@
 import BaseSegment from './BaseSegment.js';
 import { Vec3 } from '../../math/Vec3.js';
-import { T_VALUES, C_VALUES } from "./utils.js";
+import { T_VALUES, C_VALUES } from './utils.js';
 
 const tempVec3 = new Vec3();
 
 function quadraticBezier(t, p0, p1, p2) {
     const k = 1 - t;
-    return k * k * p0 + 2 * k * t *p1 + t * t * p2;
+    return k * k * p0 + 2 * k * t * p1 + t * t * p2;
 }
 
 function quadraticBezierDeriv(t, p0, p1, p2) {
@@ -23,7 +23,7 @@ export default class QuadraticBezierSegment extends BaseSegment {
 
         this.tiltStart = tiltStart;
         this.tiltEnd = tiltEnd;
-        
+
         this._len = -1;
     }
 

--- a/src/extras/Path/utils.js
+++ b/src/extras/Path/utils.js
@@ -54,7 +54,7 @@ export function mat4fromRotationSinCos(out, axis, sin, cos) {
     const y = axis[1];
     const z = axis[2];
     const t = 1 - cos;
-    
+
     out[0] = x * x * t + cos;
     out[1] = y * x * t + z * sin;
     out[2] = z * x * t - y * sin;

--- a/src/extras/Shadow.js
+++ b/src/extras/Shadow.js
@@ -14,7 +14,7 @@ export class Shadow {
         this.depthProgram = new Program(gl, {
             vertex: defaultVertex,
             fragment: defaultFragment,
-            cullFace: null,
+            cullFace: false,
         });
 
         this.castMeshes = [];
@@ -56,7 +56,7 @@ export class Shadow {
         mesh.depthProgram = new Program(this.gl, {
             vertex,
             fragment,
-            cullFace: null,
+            cullFace: false,
         });
     }
 

--- a/src/extras/WireMesh.js
+++ b/src/extras/WireMesh.js
@@ -1,10 +1,10 @@
 import { Mesh } from '../core/Mesh.js';
 import { Program } from '../core/Program.js';
 import { Geometry } from '../core/Geometry.js';
-import { Vec3 } from '../math/Vec3.js';
+import { Color } from '../math/Color.js';
 
 export class WireMesh extends Mesh {
-    constructor(gl, { geometry, wireColor = new Vec3(0, 0.75, 0.5), ...meshProps } = {}) {
+    constructor(gl, { geometry, wireColor = new Color(0, 0.75, 0.5), ...meshProps } = {}) {
         const wireProgram = new Program(gl, {
             vertex,
             fragment,

--- a/src/extras/helpers/FaceNormalsHelper.js
+++ b/src/extras/helpers/FaceNormalsHelper.js
@@ -47,7 +47,7 @@ export class FaceNormalsHelper extends Mesh {
 
             normalsArray.set(vNormal, i2);
             normalsArray.set(vNormal, i2 + 3);
-            sizeArray.set(sizeData, i / 3 * 2);
+            sizeArray.set(sizeData, (i / 3) * 2);
         }
 
         const geometry = new Geometry(gl, {


### PR DESCRIPTION
Finished going through all 46 examples (48 if you include the readme examples), I've made a number of updates, most of which are just consistent spacing and indentation, though there are some updates like the removal of unnecessary [`return await`](https://eslint.org/docs/latest/rules/no-return-await).

All of the code has been run through `prettier` and verified to be working. 😉

Process while working on the OGL typings:
1. Copy-pasted all 48 examples (including readme examples) into my [OGL Vanilla TypeScript Template](https://codesandbox.io/s/ogl-vanilla-typescript-template-5x2zhf) while working on the definitions.
2. Resolved all build errors and added definitions where needed.
3. Updated all source files with any discrepancies found.
4. Copy-pasted all the TypeScript versions of the examples back to the source files, removing the type annotations.
5. Formatted all files with the OGL `prettier` config.
6. Re-tested all the examples.

Next step is cleaning-up my working copy of all the definitions.

Related issue: #24
