### PR TITLE
Fix mobile rotation issue

### DIFF
--- a/src/extras/Orbit.js
+++ b/src/extras/Orbit.js
@@ -325,8 +325,9 @@ export function Orbit(
         }
     };
 
-    const onTouchEnd = () => {
+    const onTouchEnd = (e) => {
         if (!this.enabled) return;
+        if (e.touches.length === 1) rotateStart.set(e.touches[0].pageX, e.touches[0].pageY);
         state = STATE.NONE;
     };
 


### PR DESCRIPTION
Fixed an issue where the target would rotate at an unexpected angle after zooming when using OribtControl on mobile devices.
This is because the touch start position need to update after someone zoomed the target.