### PR TITLE
chore: add type definition GLTFAnimation re-export

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -50,6 +50,7 @@ export * from './extras/KTXTexture';
 export * from './extras/TextureLoader';
 export * from './extras/GLTFLoader';
 export * from './extras/GLTFSkin';
+export * from './extras/GLTFAnimation';
 export * from './extras/BasisManager';
 export * from './extras/WireMesh';
 export * from './extras/helpers/AxesHelper';


### PR DESCRIPTION
Just mirroring the same updates from last week, plus re-tested to make sure the existing type definitions for the class still works.

Not critical for a release, `1.0.3` works fine without it in the examples.
