### PR TITLE
fix: missing HTMLCanvasElement type in Texture.d.ts

### DIFF
--- a/types/core/Texture.d.ts
+++ b/types/core/Texture.d.ts
@@ -9,6 +9,7 @@ export type CompressedImage = {
 
 export type ImageRepresentation =
     | HTMLImageElement
+    | HTMLCanvasElement
     | HTMLVideoElement
     | HTMLImageElement[]
     | ArrayBufferView


### PR DESCRIPTION
I'm using a canvas as texture and it's working perfectly!

```typescript
const myTexture = new Texture(gl);
myTexture.image = myCanvas.canvas;
```

 But typescript complains because `HTMLCanvasElement` is not part of the typing `ImageRepresnetation`.