### PR TITLE
chore: update Program types

### DIFF
--- a/types/core/Program.d.ts
+++ b/types/core/Program.d.ts
@@ -4,6 +4,7 @@ export interface ProgramOptions {
     vertex: string;
     fragment: string;
     uniforms: Record<string, any>;
+
     transparent: boolean;
     cullFace: GLenum | false | null;
     frontFace: GLenum;
@@ -39,6 +40,8 @@ export class Program {
     blendFunc: BlendFunc;
     blendEquation: BlendEquation;
 
+    vertexShader: WebGLShader;
+    fragmentShader: WebGLShader;
     program: WebGLProgram;
     uniformLocations: Map<UniformInfo, WebGLUniformLocation>;
     attributeLocations: Map<WebGLActiveInfo, GLint>;
@@ -46,7 +49,9 @@ export class Program {
 
     constructor(gl: OGLRenderingContext, options?: Partial<ProgramOptions>);
 
-    setBlendFunc(src: GLenum, dst: GLenum, srcAlpha?: GLenum, dstAlpha?: GLenum): void;
+    setShaders(options: { vertex: string; fragment: string }): void;
+
+    setBlendFunc(src: GLenum, dst: GLenum, srcAlpha: GLenum, dstAlpha: GLenum): void;
 
     setBlendEquation(modeRGB: GLenum, modeAlpha: GLenum): void;
 


### PR DESCRIPTION
Just mirroring the same updates from last week, plus re-tested to make sure the existing type definitions for the class still works.

Not critical for a release, `1.0.4` works fine without it in the examples.
