### PR TITLE
chore: update GLTF Loader types

### DIFF
--- a/types/core/Geometry.d.ts
+++ b/types/core/Geometry.d.ts
@@ -59,6 +59,10 @@ export class Geometry {
     isInstanced: boolean;
     bounds: Bounds;
 
+    // Set from gltf loader
+    extras?: object;
+    extensions?: object;
+
     raycast?: GeometryRaycast; // User defined
 
     constructor(gl: OGLRenderingContext, attributes?: AttributeMap);

--- a/types/core/Transform.d.ts
+++ b/types/core/Transform.d.ts
@@ -2,6 +2,7 @@ import type { Euler } from '../math/Euler.js';
 import type { Mat4 } from '../math/Mat4.js';
 import type { Quat } from '../math/Quat.js';
 import type { Vec3, Vec3Tuple } from '../math/Vec3.js';
+import type { GLTFLoader } from '../extras/GLTFLoader.d.js';
 
 /**
  * The base class for most objects and provides a set of properties and methods for manipulating
@@ -75,6 +76,13 @@ export class Transform {
      * @defaultValue `new Vec3(0, 1, 0)`
      */
     up: Vec3;
+
+    /**
+     * Set from {@link GLTFLoader | GLTF Loader}.
+     */
+    name?: string;
+    extras?: object;
+    extensions?: object;
 
     /**
      * Creates a new transform object.

--- a/types/extras/GLTFLoader.d.ts
+++ b/types/extras/GLTFLoader.d.ts
@@ -137,7 +137,7 @@ export class GLTFLoader {
         gl: OGLRenderingContext,
         desc: GLTFDescription,
         images: (HTMLImageElement | ImageBitmap)[],
-        options: { sample: any; source: any; name: any; extensions: any; extras: any },
+        options: { sample: number; source: number; name: string; extensions: object; extras: object },
     ): Texture;
 
     static parseMaterials(gl: OGLRenderingContext, desc: GLTFDescription, textures: Texture[]): GLTFMaterial[] | null;


### PR DESCRIPTION
Just mirroring the same updates from a few weeks ago, plus re-tested to make sure the existing type definitions still work.

Not critical for a release, the examples and `1.0.6` work fine without it.
