### PR TITLE
fix: types Geometry

### DIFF
--- a/types/core/Geometry.d.ts
+++ b/types/core/Geometry.d.ts
@@ -81,7 +81,7 @@ export class Geometry {
 
     getPosition(): Partial<Attribute>;
 
-    computeBoundingBox(attr: Partial<Attribute>): void;
+    computeBoundingBox(attr?: Partial<Attribute>): void;
 
     computeBoundingSphere(attr?: Partial<Attribute>): void;
 

--- a/types/core/Geometry.d.ts
+++ b/types/core/Geometry.d.ts
@@ -67,7 +67,7 @@ export class Geometry {
 
     updateAttribute(attr: Partial<Attribute>): void;
 
-    setIndex(value: Attribute): void;
+    setIndex(attr: Partial<Attribute>): void;
 
     setDrawRange(start: number, count: number): void;
 


### PR DESCRIPTION
The argument for `setIndex()` should be `Partial<Attribute>`.

And the argument for `computeBoundingBox()` is optional.

Closes #209