### PR TITLE
chore: update Vec2 and Vec3 types

### DIFF
--- a/types/math/Vec2.d.ts
+++ b/types/math/Vec2.d.ts
@@ -59,6 +59,8 @@ export class Vec2 extends Array<number> {
 
     lerp(v: Vec2, a: number): this;
 
+    smoothLerp(v: Vec2, decay: number, dt: number): this;
+
     clone(): Vec2;
 
     fromArray(a: number[] | AttributeData, o?: number): this;

--- a/types/math/Vec3.d.ts
+++ b/types/math/Vec3.d.ts
@@ -70,6 +70,8 @@ export class Vec3 extends Array<number> {
 
     lerp(v: Vec3, t: number): this;
 
+    smoothLerp(v: Vec3, decay: number, dt: number): this;
+
     clone(): Vec3;
 
     fromArray(a: number[] | AttributeData, o?: number): this;


### PR DESCRIPTION
Adding `smoothLerp()` from @DougLilliequist's last commit. 😉