### PR TITLE
fix: gltf examples compressed links

### DIFF
--- a/examples/gltf-ktx2-basis.html
+++ b/examples/gltf-ktx2-basis.html
@@ -13,7 +13,7 @@
         <div class="Info" style="color: #fff">
             GLTF KTX2 Basis Extension. Model by
             <a href="https://sketchfab.com/3d-models/painterly-cottage-0772aec70d584c60a27000af5f6c1ef4" target="_blank">Glenatron</a>
-            <br /><a href="/examples/?src=gltf-ktx2-basis-draco.html" target="_top">Draco Compressed Version</a>
+            <br /><a href="/ogl/examples/?src=gltf-ktx2-basis-draco.html" target="_top">Draco Compressed Version</a>
         </div>
         <script type="module">
             // I use GLTF-Transform to compress GLTF files' textures with Basis compression

--- a/examples/load-gltf.html
+++ b/examples/load-gltf.html
@@ -13,7 +13,7 @@
         <div class="Info" style="color: #fff">
             Load GLTF (Graphics Language Transmission Format). Model by
             <a href="https://sketchfab.com/3d-models/hershel-little-america-f4d7a0ed8af2453e9adc632278c9aa50" target="_blank">VRModelFactory</a>
-            <br /><a href="/examples/?src=gltf-draco-webp.html" target="_top">Draco and WebP Compressed Version</a>
+            <br /><a href="/ogl/examples/?src=gltf-draco-webp.html" target="_top">Draco and WebP Compressed Version</a>
         </div>
         <script type="module">
             import { Renderer, Camera, Transform, Orbit, Program, GLTFLoader, Vec3, TextureLoader } from '../src/index.js';


### PR DESCRIPTION
Whoops, should have tested the example links from GitHub Pages!

Related PR: #245
